### PR TITLE
Allow setting custom deployment labels

### DIFF
--- a/rocketchat/templates/deployment.yaml
+++ b/rocketchat/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: {{ include "rocketchat.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.deploymentLabels }}
+{{ toYaml .Values.deploymentLabels | indent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -162,6 +162,9 @@ service:
 
   port: 80
 
+## Optional custom labels for the deployment resource.
+deploymentLabels: {}
+
 ## Optional Pod Labels.
 podLabels: {}
 


### PR DESCRIPTION
We need this so we can set some labels so the backup system velero knows which resources to restore from a backup.