### PR TITLE
Update helm chart to actually build and add ingress v1 support

### DIFF
--- a/rocketchat/templates/ingress.yaml
+++ b/rocketchat/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
 {{- if $ingress.tls }}
   tls:
   {{- range $ingress.tls }}
@@ -31,7 +34,7 @@ spec:
     http:
       paths:
       - path: {{ $ingress.path }}
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: {{ template "rocketchat.fullname" . }}

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -139,9 +139,11 @@ ingress:
   enabled: false
   annotations:
     {}
+  # ingressClassName: "nxinx"
+  annotations: {}
     # kubernetes.io/ingress.class: "nginx"
   path: /
-  tls:
+  tls: {}
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local


### PR DESCRIPTION
This PR adds support for kubernetes v1.22 due to the removal of v1beta1 ingress,
and a values file that includes the previously missing fields.
