### PR TITLE
Including a parameter for Rocket.Chat Cloud's Registration Token

### DIFF
--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -10,6 +10,11 @@
 $ helm install rocketchat rocketchat/rocketchat --set mongodb.auth.password=$(echo -n $(openssl rand -base64 32)),mongodb.auth.rootPassword=$(echo -n $(openssl rand -base64 32))
 ```
 
+If you got a registration token for [Rocket.Chat Cloud](https://cloud.rocket.chat), you can also include it: 
+```console
+$ helm install rocketchat rocketchat/rocketchat --set mongodb.auth.password=$(echo -n $(openssl rand -base64 32)),mongodb.auth.rootPassword=$(echo -n $(openssl rand -base64 32)),registrationToken=<paste the token here>
+```
+
 ## Introduction
 
 This chart bootstraps a [Rocket.Chat](https://rocket.chat/) Deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. It provisions a fully featured Rocket.Chat installation.
@@ -89,6 +94,7 @@ Parameter | Description | Default
 `readinessProbe.timeoutSeconds` | When the probe times out | `5`
 `readinessProbe.failureThreshold` | Minimum consecutive failures for the probe | `3`
 `readinessProbe.successThreshold` | Minimum consecutive successes for the probe | `1`
+`registrationToken` | Registration Token for [Rocket.Chat Cloud ](https://cloud.rocket.chat) | ""
 `service.annotations` | Annotations for the Rocket.Chat service | `{}`
 `service.labels` | Additional labels for the Rocket.Chat service | `{}`
 `service.type` | The service type to use | `ClusterIP`

--- a/rocketchat/templates/deployment.yaml
+++ b/rocketchat/templates/deployment.yaml
@@ -92,6 +92,13 @@ spec:
               name: {{ template "rocketchat.fullname" . }}
               key: mail-url
         {{- end }}
+        {{- if .Values.registrationToken }}
+        - name: REG_TOKEN
+          valueFrom: 
+            secretKeyRef: 
+              name: {{ template "rocketchat.fullname" . }}
+              key: reg-token
+        {{- end }}
 {{- with .Values.extraEnv }}
 {{ tpl . $ | indent 8 }}
 {{- end }}

--- a/rocketchat/templates/secret.yaml
+++ b/rocketchat/templates/secret.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
+{{- if .Values.registrationToken }}
+  reg-token: {{ .Values.registrationToken | b64enc | quote }}
+{{ end }}
 {{- if .Values.smtp.enabled }}
   mail-url: {{ printf "smtp://%s:%s@%s:%.0f" .Values.smtp.username .Values.smtp.password .Values.smtp.host .Values.smtp.port | b64enc | quote }}
 {{- end }}

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -29,6 +29,9 @@ extraEnv:
   # - name: MONGO_OPLOG_URL
   #   value: mongodb://oploguser:password@rocket-1:27017/local&replicaSet=rs0
 
+## Specifies a Registration Token (obtainable at https://cloud.rocket.chat)
+#registrationToken: ""
+
 ## Pod anti-affinity can prevent the scheduler from placing RocketChat replicas on the same node.
 ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
 ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.


### PR DESCRIPTION
Allows Registration Token to be specified as a parameter, rather than an explicit environment variable. 