### PR TITLE
Allows for enterprise license inclusion per means of environment variable

### DIFF
--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -82,7 +82,7 @@ Parameter | Description | Default
 `ingress.annotations` | Annotations for the ingress | `{}`
 `ingress.path` | Path of the ingress | `/`
 `ingress.tls` | A list of [IngressTLS](https://kubernetes.io/docs/reference/federation/extensions/v1beta1/definitions/#_v1beta1_ingresstls) items | `[]`
-`license` | Contents of the Enterprise License file, if appliable | `""`
+`license` | Contents of the Enterprise License file, if applicable | `""`
 `livenessProbe.enabled` | Turn on and off liveness probe | `true`
 `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | `60`
 `livenessProbe.periodSeconds` | How often to perform the probe | `15`

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -82,6 +82,7 @@ Parameter | Description | Default
 `ingress.annotations` | Annotations for the ingress | `{}`
 `ingress.path` | Path of the ingress | `/`
 `ingress.tls` | A list of [IngressTLS](https://kubernetes.io/docs/reference/federation/extensions/v1beta1/definitions/#_v1beta1_ingresstls) items | `[]`
+`license` | Contents of the Enterprise License file, if appliable | `""`
 `livenessProbe.enabled` | Turn on and off liveness probe | `true`
 `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | `60`
 `livenessProbe.periodSeconds` | How often to perform the probe | `15`

--- a/rocketchat/templates/deployment.yaml
+++ b/rocketchat/templates/deployment.yaml
@@ -99,6 +99,13 @@ spec:
               name: {{ template "rocketchat.fullname" . }}
               key: reg-token
         {{- end }}
+        {{- if .Values.license }}
+        - name: ROCKETCHAT_LICENSE
+          valueFrom: 
+            secretKeyRef: 
+              name: {{ template "rocketchat.fullname" . }}
+              key: license
+        {{- end }}
 {{- with .Values.extraEnv }}
 {{ tpl . $ | indent 8 }}
 {{- end }}

--- a/rocketchat/templates/secret.yaml
+++ b/rocketchat/templates/secret.yaml
@@ -13,6 +13,9 @@ data:
 {{- if .Values.registrationToken }}
   reg-token: {{ .Values.registrationToken | b64enc | quote }}
 {{ end }}
+{{- if .Values.license }}
+  license: {{ .Values.license | b64enc | quote }}
+{{ end }}
 {{- if .Values.smtp.enabled }}
   mail-url: {{ printf "smtp://%s:%s@%s:%.0f" .Values.smtp.username .Values.smtp.password .Values.smtp.host .Values.smtp.port | b64enc | quote }}
 {{- end }}

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -31,6 +31,9 @@ extraEnv:
 ## Specifies a Registration Token (obtainable at https://cloud.rocket.chat)
 #registrationToken: ""
 
+## Specifies an Enterprise License
+# license: ""
+
 ## Pod anti-affinity can prevent the scheduler from placing RocketChat replicas on the same node.
 ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
 ## The value "hard" means that the scheduler is *required* to not schedule two replica pods onto the same node.


### PR DESCRIPTION
There's now a `license' field, which can receive the contents of an enterprise license file, thus avoiding the need of uploading it through administrative interface.