### PR TITLE
Automate helm release using Github Actions

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -18,6 +18,9 @@ jobs:
           echo "ROCKETCHAT_VERSION=$ROCKETCHAT_VERSION" >> $GITHUB_ENV
           [[ -z "$(echo ${{ env.ROCKETCHAT_VERSION }} | grep rc)" ]] && echo "CANDIDATE=false" >> $GITHUB_ENV
 
+      # this section was for when this PR was meant to be added to the main rocketchat repo, so it could be part of the main app release process
+      # -------------------------------------------------
+
       # - name: Set SSH key for helm-chart repo
       #   if: env.CANDIDATE == 'false'
       #   uses: webfactory/ssh-agent@v0.5.3
@@ -30,7 +33,7 @@ jobs:
 
       # - name: Clone helm repo (gh-pages)
       #   run: "git clone --branch gh-pages git@github.com:${{ env.HELM_REPO }} gh-pages"
-
+      # -------------------------------------------------
 
       - name: Clone helm repo (master)
         uses: actions/checkout@v2

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -25,11 +25,26 @@ jobs:
       #       ssh-private-key: ${{ secrets.HELM_REPO_SSH_KEY }}
 
       # not using the checkout action because we need to push to this repo using the ssh-agent we just set up above
-      - name: Clone helm repo (master)
-        run: "git clone git@github.com:${{ env.HELM_REPO }} helm-charts"
+      # - name: Clone helm repo (master)
+      #   run: "git clone git@github.com:${{ env.HELM_REPO }} helm-charts"
 
+      # - name: Clone helm repo (gh-pages)
+      #   run: "git clone --branch gh-pages git@github.com:${{ env.HELM_REPO }} gh-pages"
+
+
+      - name: Clone helm repo (master)
+        uses: actions/checkout@v2
+        with:
+          repository: "${{ env.HELM_REPO }}"
+          path: './helm-charts'
+      
       - name: Clone helm repo (gh-pages)
-        run: "git clone --branch gh-pages git@github.com:${{ env.HELM_REPO }} gh-pages"
+        uses: actions/checkout@v2
+        with:
+          repository: "${{ env.HELM_REPO }}"
+          ref: 'gh-pages'
+          path: './gh-pages'
+      
 
       - name: Clone tests repo
         uses: actions/checkout@v2

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -1,0 +1,115 @@
+name: Update helm chart
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update_helm_chart:
+    env:
+      HELM_REPO: r0zbot/helm-charts #TODO: mudar!
+      TESTS_REPO: RocketChat/rocketchat-release-tests
+    runs-on: ubuntu-18.04
+    if: github.event_name == 'release'
+    steps:
+      - name: Parse environment variables
+        run: |
+          export ROCKETCHAT_VERSION=${{ github.event.release.tag_name }}
+          echo "ROCKETCHAT_VERSION=$ROCKETCHAT_VERSION" >> $GITHUB_ENV
+          [[ -z "$(echo ${{ env.ROCKETCHAT_VERSION }} | grep rc)" ]] && echo "CANDIDATE=false" >> $GITHUB_ENV
+
+      - name: Set SSH key for helm-chart repo
+        if: env.CANDIDATE == 'false'
+        uses: webfactory/ssh-agent@v0.5.3
+        with:
+            ssh-private-key: ${{ secrets.HELM_REPO_SSH_KEY }}
+
+      # not using the checkout action because we need to push to this repo using the ssh-agent we just set up above
+      - name: Clone helm repo (master)
+        run: "git clone git@github.com:${{ env.HELM_REPO }} helm-charts"
+
+      - name: Clone helm repo (gh-pages)
+        run: "git clone --branch gh-pages git@github.com:${{ env.HELM_REPO }} gh-pages"
+
+      - name: Clone tests repo
+        uses: actions/checkout@v2
+        with:
+          repository: "${{ env.TESTS_REPO }}"
+          path: './test_scripts'
+      
+      - name: Setup k3d
+        uses: nolar/setup-k3d-k3s@v1
+
+      - name: Update chart and rocketchat versions 
+        id: version
+        run: |
+          sed -i -r '/^appVersion:/ s/ .+/ ${{ env.ROCKETCHAT_VERSION }}/' ./helm-charts/rocketchat/Chart.yaml
+          sed -i -r '/^version:/ s/ .+/ ${{ env.ROCKETCHAT_VERSION }}/' ./helm-charts/rocketchat/Chart.yaml
+      
+      - name: Pull dependencies
+        run: helm dependency update ./helm-charts/rocketchat
+      
+      - name: Generate helm package
+        run: helm package ./helm-charts/rocketchat && cp rocketchat-${{ env.ROCKETCHAT_VERSION }}.tgz gh-pages/charts/
+
+      - name: Install helm package
+        run: helm install --set mongodb.auth.username=rocketchat,mongodb.auth.password=testpass,mongodb.auth.database=rocketchat,mongodb.auth.rootPassword=root-testpass test-install-rocketchat rocketchat-${{ env.ROCKETCHAT_VERSION }}.tgz
+
+      - name: Test helm installation
+        run: helm test --logs test-install-rocketchat
+
+      - name: Test helm upgrade
+        run: |
+          helm repo add r0zbot https://r0zbot.github.io/helm-charts #TODO CHANGE THIS
+          helm install --set mongodb.auth.username=rocketchat,mongodb.auth.password=testpass,mongodb.auth.database=rocketchat,mongodb.auth.rootPassword=root-testpass test-upgrade-rocketchat r0zbot/rocketchat
+          sleep 20
+          timeout 360 kubectl port-forward --pod-running-timeout=1m0s --namespace default $(kubectl get pods --namespace default -l "app.kubernetes.io/name=rocketchat,app.kubernetes.io/instance=test-upgrade-rocketchat" -o jsonpath='{ .items[0].metadata.name }') 8888:3000 &
+          sleep 60
+          ./test_scripts/wait_http.sh http://127.0.0.1:8888
+          . ./test_scripts/basic_test.sh http://127.0.0.1:8888
+          helm upgrade test-upgrade-rocketchat rocketchat-${{ env.ROCKETCHAT_VERSION }}.tgz
+          helm test --logs test-install-rocketchat
+
+          echo "Seeing if information persisted across updates"
+          test_endpoint "$base_url/api/v1/channels.messages?roomId=GENERAL" -H "$userId" -H "$authToken"
+          if [[ "$response" != *"This is a test message from $TEST_USER"* ]]; then
+            echo "Couldn't find sent message. Somethings wrong!"
+            exit 2
+          fi
+
+          echo "Tests passed!"
+          
+
+      - name: Re-generate helm index
+        run: helm repo index ./gh-pages/
+      
+      - name: Push to master
+        uses: EndBug/add-and-commit@v7
+        with:
+          add: 'rocketchat/Chart.yaml'
+          cwd: helm-charts
+          branch: master
+          message: "Chore: bump Rocket.Chat and chart version to ${{ env.ROCKETCHAT_VERSION }}"
+          push: true
+          default_author: github_actions
+      
+      - name: Push to gh-pages
+        uses: EndBug/add-and-commit@v7
+        with:
+          add: '.'
+          cwd: gh-pages
+          branch: gh-pages
+          message: "Chore: bump Rocket.Chat and chart version to ${{ env.ROCKETCHAT_VERSION }}"
+          push: true
+          default_author: github_actions
+      
+      
+      # - name: Rocket.Chat Notification
+      #   uses: RocketChat/Rocket.Chat.GitHub.Action.Notification@master
+      #   if: env.CANDIDATE == 'false'
+      #   with:
+      #     type: ${{ job.status }}
+      #     job_name: '*Snapcraft build*'
+      #     mention: 'here'
+      #     mention_if: 'failure'
+      #     url: ${{ secrets.ROCKETCHAT_WEBHOOK }}

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -77,10 +77,10 @@ jobs:
         run: |
           helm repo add rocketchat https://rocketchat.github.io/helm-charts
           helm install --set mongodb.auth.username=rocketchat,mongodb.auth.password=testpass,mongodb.auth.database=rocketchat,mongodb.auth.rootPassword=root-testpass test-upgrade-rocketchat rocketchat/rocketchat
-          sleep 40
-          timeout 360 kubectl port-forward --pod-running-timeout=1m0s --namespace default $(kubectl get pods --namespace default -l "app.kubernetes.io/name=rocketchat,app.kubernetes.io/instance=test-upgrade-rocketchat" -o jsonpath='{ .items[0].metadata.name }') 8888:3000 &
           echo waiting for pod to be created
-          sleep 100
+          sleep 80
+          timeout 360 kubectl port-forward --pod-running-timeout=1m0s --namespace default $(kubectl get pods --namespace default -l "app.kubernetes.io/name=rocketchat,app.kubernetes.io/instance=test-upgrade-rocketchat" -o jsonpath='{ .items[0].metadata.name }') 8888:3000 &
+          sleep 40
           ./test_scripts/wait_http.sh http://127.0.0.1:8888
           . ./test_scripts/basic_test.sh http://127.0.0.1:8888
           helm upgrade test-upgrade-rocketchat rocketchat-${{ env.ROCKETCHAT_VERSION }}.tgz

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -18,11 +18,11 @@ jobs:
           echo "ROCKETCHAT_VERSION=$ROCKETCHAT_VERSION" >> $GITHUB_ENV
           [[ -z "$(echo ${{ env.ROCKETCHAT_VERSION }} | grep rc)" ]] && echo "CANDIDATE=false" >> $GITHUB_ENV
 
-      - name: Set SSH key for helm-chart repo
-        if: env.CANDIDATE == 'false'
-        uses: webfactory/ssh-agent@v0.5.3
-        with:
-            ssh-private-key: ${{ secrets.HELM_REPO_SSH_KEY }}
+      # - name: Set SSH key for helm-chart repo
+      #   if: env.CANDIDATE == 'false'
+      #   uses: webfactory/ssh-agent@v0.5.3
+      #   with:
+      #       ssh-private-key: ${{ secrets.HELM_REPO_SSH_KEY }}
 
       # not using the checkout action because we need to push to this repo using the ssh-agent we just set up above
       - name: Clone helm repo (master)

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -75,9 +75,9 @@ jobs:
 
       - name: Test helm upgrade
         run: |
-          helm repo add r0zbot https://r0zbot.github.io/helm-charts #TODO CHANGE THIS
+          helm repo add r0zbot https://rocketchat.github.io/helm-charts
           helm install --set mongodb.auth.username=rocketchat,mongodb.auth.password=testpass,mongodb.auth.database=rocketchat,mongodb.auth.rootPassword=root-testpass test-upgrade-rocketchat r0zbot/rocketchat
-          sleep 20
+          sleep 40
           timeout 360 kubectl port-forward --pod-running-timeout=1m0s --namespace default $(kubectl get pods --namespace default -l "app.kubernetes.io/name=rocketchat,app.kubernetes.io/instance=test-upgrade-rocketchat" -o jsonpath='{ .items[0].metadata.name }') 8888:3000 &
           sleep 60
           ./test_scripts/wait_http.sh http://127.0.0.1:8888

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -80,7 +80,7 @@ jobs:
           echo waiting for pod to be created
           sleep 80
           timeout 360 kubectl port-forward --pod-running-timeout=1m0s --namespace default $(kubectl get pods --namespace default -l "app.kubernetes.io/name=rocketchat,app.kubernetes.io/instance=test-upgrade-rocketchat" -o jsonpath='{ .items[0].metadata.name }') 8888:3000 &
-          sleep 40
+          sleep 5
           ./test_scripts/wait_http.sh http://127.0.0.1:8888
           . ./test_scripts/basic_test.sh http://127.0.0.1:8888
           helm upgrade test-upgrade-rocketchat rocketchat-${{ env.ROCKETCHAT_VERSION }}.tgz

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -75,11 +75,12 @@ jobs:
 
       - name: Test helm upgrade
         run: |
-          helm repo add r0zbot https://rocketchat.github.io/helm-charts
-          helm install --set mongodb.auth.username=rocketchat,mongodb.auth.password=testpass,mongodb.auth.database=rocketchat,mongodb.auth.rootPassword=root-testpass test-upgrade-rocketchat r0zbot/rocketchat
+          helm repo add rocketchat https://rocketchat.github.io/helm-charts
+          helm install --set mongodb.auth.username=rocketchat,mongodb.auth.password=testpass,mongodb.auth.database=rocketchat,mongodb.auth.rootPassword=root-testpass test-upgrade-rocketchat rocketchat/rocketchat
           sleep 40
           timeout 360 kubectl port-forward --pod-running-timeout=1m0s --namespace default $(kubectl get pods --namespace default -l "app.kubernetes.io/name=rocketchat,app.kubernetes.io/instance=test-upgrade-rocketchat" -o jsonpath='{ .items[0].metadata.name }') 8888:3000 &
-          sleep 60
+          echo waiting for pod to be created
+          sleep 100
           ./test_scripts/wait_http.sh http://127.0.0.1:8888
           . ./test_scripts/basic_test.sh http://127.0.0.1:8888
           helm upgrade test-upgrade-rocketchat rocketchat-${{ env.ROCKETCHAT_VERSION }}.tgz


### PR DESCRIPTION
When a new release is created in this repo, this action creates the .tgz file, tests it for regressions and then pushes it to the gh-pages branch.

This was meant to be a part of the main app release process, but since https://github.com/RocketChat/Rocket.Chat/pull/22189 was never merged, I'm adding it to this repo too.

One thing to note is that this marries the appVersion with the chart version, so that both of them should always be in sync.

Also, should we add a notification to a rocketchat channel about this release?