### PR TITLE
fix: add emptyDir tmp volume

### DIFF
--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -179,7 +179,11 @@ spec:
         volumeMounts:
         - name: rocket-data
           mountPath: /app/uploads
+        - name: tmp
+          mountPath: /tmp
       volumes:
+      - name: tmp
+        emptyDir: {}
       - name: rocket-data
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:


### PR DESCRIPTION
Description:
This PR adds a emptyDir volume at /tmp path. This is needed, because Rocket tries to create files and folders under /tmp and if you're running with a strict pod policy, the filesystem is read-only.

