### PR TITLE
[Fix] Use prometheusScraping.port variable and honor prometheusScraping.enabled

### DIFF
--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -150,8 +150,10 @@ spec:
         ports:
         - name: http
           containerPort: 3000
+        {{- if .Values.prometheusScraping.enabled }}
         - name: metrics
-          containerPort: 9458
+          containerPort: "{{ .Values.prometheusScraping.port }}"
+        {{- end}}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Setting a custom value for `prometheusScraping.port` in `values.yaml` has no effect, as the variable isn't actually being used in the port definition in `chat-deployment.yaml`.