### PR TITLE
[Fix] Use prometheusScraping variables

### DIFF
--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -152,7 +152,7 @@ spec:
           containerPort: 3000
         {{- if .Values.prometheusScraping.enabled }}
         - name: metrics
-          containerPort: "{{ .Values.prometheusScraping.port }}"
+          containerPort: {{ .Values.prometheusScraping.port }}
         {{- end}}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -150,8 +150,10 @@ spec:
         ports:
         - name: http
           containerPort: 3000
+        {{- if .Values.prometheusScraping.enabled }}
         - name: metrics
-          containerPort: 9458
+          containerPort: "{{ .Values.prometheusScraping.port }}"
+        {{- end}}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/rocketchat/templates/service.yaml
+++ b/rocketchat/templates/service.yaml
@@ -30,6 +30,12 @@ spec:
     nodePort: {{ $service.nodePort }}
     {{- end }}
     protocol: TCP
+  {{- if .Values.prometheusScraping.enabled }}
+  - name: metrics
+    port: {{ .Values.prometheusScraping.port }}
+    targetPort: metrics
+    protocol: TCP
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "rocketchat.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
**Problem:**
Setting a custom value for `prometheusScraping.port` in `values.yaml` has no effect, as the variable isn't actually being used in the port definition in `chat-deployment.yaml`.

**Solution:**
Add the variable to port definitions in `chat-deployment.yaml` and fence it so the port only gets defined when `prometheusScraping.enabled` is true.

Also add a `metrics` port to the service, so prometheus can scrape it.