### PR TITLE
Use replicaSet param in mongodb-uri

### DIFF
--- a/rocketchat/templates/secret.yaml
+++ b/rocketchat/templates/secret.yaml
@@ -23,6 +23,6 @@ data:
   {{- $rsName := .Values.mongodb.replicaSetName }}
   {{- $port := .Values.mongodb.service.port }}
   {{- $dbname := required "Please specify a MongoDB database" .Values.mongodb.auth.database }}
-  mongo-uri: {{ printf "mongodb://%s:%s@%s:%.0f/%s" $username $password $fullname $port $dbname | b64enc | quote }}
+  mongo-uri: {{ printf "mongodb://%s:%s@%s:%.0f/%s?replicaSet=%s" $username $password $fullname $port $dbname $rsName | b64enc | quote }}
   mongo-oplog-uri: {{ printf "mongodb://root:%s@%s:%.0f/local?replicaSet=%s&authSource=admin" $rootPassword $fullname $port $rsName | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
Replicaset param is required when using internal mongodb with more than one replica.