### PR TITLE
Remove duplicated keys in values

### DIFF
--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -153,8 +153,6 @@ serviceAccount:
 ingress:
   enabled: false
   pathType: Prefix
-  annotations:
-    {}
   # ingressClassName: "nxinx"
   annotations: {}
     # kubernetes.io/ingress.class: "nginx"
@@ -252,4 +250,3 @@ microservices:
   streamHubService: 
   accountsService: 
   authorizationService: 
-  natsService: 


### PR DESCRIPTION
These duplicated keys makes this yaml invalid. This is a problem when you use Helm managers like Kubeapps or rancher when you try tu upgrade, they use the default values from this file and throws an error.
<img width="1039" alt="duplicated-keys" src="https://user-images.githubusercontent.com/38347/159034896-1a1bd5f3-a030-4332-ae85-f6c601c1158c.png">

