### PR TITLE
allow SMTP from existing secret

### DIFF
--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -54,6 +54,7 @@ Parameter | Description | Default
 `host` | Hostname for Rocket.Chat. Also used for ingress (if enabled) | `""`
 `replicaCount` | Number of replicas to run | `1`
 `smtp.enabled` | Enable SMTP for sending mails | `false`
+`smtp.existingSecret` | Use existing secret for SMTP account | `""`
 `smtp.username` | Username of the SMTP account | `""`
 `smtp.password` | Password of the SMTP account | `""`
 `smtp.host` | Hostname of the SMTP server | `""`

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -86,11 +86,19 @@ spec:
           value: https://{{ .Values.host }}
         {{- end }}
         {{- if .Values.smtp.enabled }}
+        {{- if not .Values.smtp.existingSecret }}
         - name: MAIL_URL
           valueFrom:
             secretKeyRef:
               name: {{ template "rocketchat.fullname" . }}
               key: mail-url
+        {{- else }}
+        - name: MAIL_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.smtp.existingSecret }}
+              key: mail-url
+        {{- end }}
         {{- end }}
         {{- if .Values.registrationToken }}
         - name: REG_TOKEN

--- a/rocketchat/templates/secret.yaml
+++ b/rocketchat/templates/secret.yaml
@@ -17,7 +17,9 @@ data:
   license: {{ .Values.license | b64enc | quote }}
 {{ end }}
 {{- if .Values.smtp.enabled }}
+{{- if not .Values.smtp.existingSecret}}
   mail-url: {{ printf "smtp://%s:%s@%s:%.0f" .Values.smtp.username .Values.smtp.password .Values.smtp.host .Values.smtp.port | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- if not .Values.existingMongodbSecret }}
 {{- if .Values.externalMongodbUrl }}


### PR DESCRIPTION
Allow SMTP config in existing secret to facilitate integration with CI/CD workflows without exposing secrets in repositories.