### PR TITLE
Add Kubernetes serviceMonitor resource

### DIFF
--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -87,6 +87,10 @@ Parameter | Description | Default
 `license` | Contents of the Enterprise License file, if applicable | `""`
 `prometheusScraping.enabled` | Turn on and off /metrics endpoint for Prometheus scraping | `false`
 `prometheusScraping.port` | Port to use for the metrics for Prometheus to scrap on | `9458`
+`serviceMonitor.enabled` | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator (prometheusScraping should be enabled) | `false`
+`serviceMonitor.interval` | The interval at which metrics should be scraped | `30s`
+`serviceMonitor.path` | /metrics endpoint for Prometheus scraping | `/metrics`
+`serviceMonitor.port` | The port name at which container exposes Prometheus metrics | `metrics`
 `livenessProbe.enabled` | Turn on and off liveness probe | `true`
 `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | `60`
 `livenessProbe.periodSeconds` | How often to perform the probe | `15`

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -89,7 +89,6 @@ Parameter | Description | Default
 `prometheusScraping.port` | Port to use for the metrics for Prometheus to scrap on | `9458`
 `serviceMonitor.enabled` | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator (prometheusScraping should be enabled) | `false`
 `serviceMonitor.interval` | The interval at which metrics should be scraped | `30s`
-`serviceMonitor.path` | /metrics endpoint for Prometheus scraping | `/metrics`
 `serviceMonitor.port` | The port name at which container exposes Prometheus metrics | `metrics`
 `livenessProbe.enabled` | Turn on and off liveness probe | `true`
 `livenessProbe.initialDelaySeconds` | Delay before liveness probe is initiated | `60`

--- a/rocketchat/templates/servicemonitor.yaml
+++ b/rocketchat/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.serviceMonitor.enabled .Values.prometheusScraping.enabled}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "rocketchat.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "rocketchat.name" . }}
+    helm.sh/chart: {{ include "rocketchat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  endpoints:
+    - port: {{ .Values.prometheusScraping.port }}
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rocketchat.name" . }}
+      helm.sh/chart: {{ include "rocketchat.chart" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/rocketchat/templates/servicemonitor.yaml
+++ b/rocketchat/templates/servicemonitor.yaml
@@ -11,7 +11,6 @@ metadata:
 spec:
   endpoints:
     - port: {{ .Values.serviceMonitor.port }}
-      path: {{ .Values.serviceMonitor.path }}
       interval: {{ .Values.serviceMonitor.interval }}
   selector:
     matchLabels:

--- a/rocketchat/templates/servicemonitor.yaml
+++ b/rocketchat/templates/servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   endpoints:
-    - port: {{ .Values.prometheusScraping.port }}
+    - port: {{ .Values.serviceMonitor.port }}
       path: {{ .Values.serviceMonitor.path }}
       interval: {{ .Values.serviceMonitor.interval }}
   selector:

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -194,6 +194,13 @@ prometheusScraping:
   enabled: false
   port: 9458
 
+serviceMonitor:
+## @param serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
+##
+  enabled: false
+  interval: 30s
+  path: /metrics
+
 ## Liveness and readiness probe values
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 ##

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -202,9 +202,6 @@ serviceMonitor:
   ## metrics.serviceMonitor.interval The interval at which metrics should be scraped
   ##
   interval: 30s
-  ## metrics.serviceMonitor.path The path at which metrics should be scraped
-  ##
-  path: /metrics
   ## metrics.serviceMonitor.port The port name at which container exposes Prometheus metrics
   ##
   port: metrics

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -195,11 +195,19 @@ prometheusScraping:
   port: 9458
 
 serviceMonitor:
-## @param serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
-##
+  ## serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
+  ## prometheusScraping.enabled should be also enabled
+  ##
   enabled: false
+  ## metrics.serviceMonitor.interval The interval at which metrics should be scraped
+  ##
   interval: 30s
+  ## metrics.serviceMonitor.path The path at which metrics should be scraped
+  ##
   path: /metrics
+  ## metrics.serviceMonitor.port The port name at which container exposes Prometheus metrics
+  ##
+  port: metrics
 
 ## Liveness and readiness probe values
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes


### PR DESCRIPTION
Add ServiceMonitor resource which declaratively specifies how groups of Kubernetes services should be monitored.

The [prometheus-operator]( https://github.com/coreos/prometheus-operator) automatically generates Prometheus scrape configuration based on the current state of the objects in the API server.