### PR TITLE
fix: possibility to add service account annotations

### DIFF
--- a/rocketchat/Chart.yaml
+++ b/rocketchat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rocketchat
-version: 4.7.0
+version: 4.7.1
 appVersion: 4.7.0
 dependencies:
   - name: mongodb

--- a/rocketchat/Chart.yaml
+++ b/rocketchat/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: rocketchat
-version: 4.7.1
+version: 4.7.0
 appVersion: 4.7.0
 dependencies:
   - name: mongodb

--- a/rocketchat/templates/serviceaccount.yaml
+++ b/rocketchat/templates/serviceaccount.yaml
@@ -7,5 +7,9 @@ metadata:
     helm.sh/chart: {{ include "rocketchat.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+    annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ template "rocketchat.serviceAccountName" . }}
 {{- end -}}

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -140,6 +140,10 @@ securityContext:
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+  
+  # Annotations to add to the ServiceAccount
+  annotations: {}
+  # eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/dummyRole
 
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template


### PR DESCRIPTION
Needed when using AWS IRSA and only create the IAM role without the serviceAccount.

Signed-off-by: Höhl, Lukas <lukas.hoehl@accso.de>