### PR TITLE
Fix: values.yaml: ingress.tls default type should []

### DIFF
--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -180,7 +180,7 @@ ingress:
     {}
     # kubernetes.io/ingress.class: "nginx"
   path: /
-  tls: {}
+  tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local


### PR DESCRIPTION
Fix warning when settings `ingress.tls` values.

```
coalesce.go:220: warning: cannot overwrite table with non table for rocketchat.ingress.tls (map[])
```
