### PR TITLE
Update mongodb chart to recent version as dependency.

### DIFF
--- a/rocketchat/Chart.yaml
+++ b/rocketchat/Chart.yaml
@@ -5,7 +5,7 @@ appVersion: 5.3.1
 dependencies:
   - name: mongodb
     repository: https://charts.bitnami.com/bitnami
-    version: 10.x.x
+    version: 13.x.x
     condition: mongodb.enabled
   - name: nats
     repository: https://nats-io.github.io/k8s/helm/charts

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -96,6 +96,8 @@ mongodb:
   enabled: true
 
   initdbScriptsConfigMap: rocketchat-mongodb-fix-clustermonitor-role-configmap
+  image:
+    tag: 5.0
 
   auth:
     # rootPassword:


### PR DESCRIPTION
bitnami removed all old chart versions, so let's upgrade to a recent one an pin the mongodb version to a rocketchat-supported version.

When not doing this, errors appear like (in this case only when using helm+git, but we should update the chart anyways):

```
  Error: can't get a valid version for repositories mongodb. Try changing the version constraint in Chart.yaml
  Error in plugin 'helm-git': Error while helm_dependency_update
...
```
