### PR TITLE
Make liveness/readiness probe configurable

### DIFF
--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -149,7 +149,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /api/info
+            path: {{ .Values.livenessProbe.path }}
             port: http
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -160,7 +160,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /api/info
+            path: {{ .Values.readinessProbe.path }}
             port: http
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -243,6 +243,7 @@ serviceMonitor:
 ##
 livenessProbe:
   enabled: true
+  path: /health
   initialDelaySeconds: 60
   periodSeconds: 15
   timeoutSeconds: 5
@@ -251,6 +252,7 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
+  path: /health
   initialDelaySeconds: 10
   periodSeconds: 15
   timeoutSeconds: 5


### PR DESCRIPTION
This was already merged in https://github.com/RocketChat/helm-charts/pull/79, but somehow I do not see the commit or change in https://github.com/RocketChat/helm-charts/blob/master/rocketchat/templates/chat-deployment.yaml#L152, so let's merge it again please.