### PR TITLE
Finalizer config for ingress

### DIFF
--- a/rocketchat/templates/ingress.yaml
+++ b/rocketchat/templates/ingress.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
+{{- if .Values.ingress.finalizers }}
+  finalizers: {{ .Values.ingress.finalizers }}
+{{- end }}
   labels:
     app.kubernetes.io/name: {{ include "rocketchat.name" . }}
     helm.sh/chart: {{ include "rocketchat.chart" . }}


### PR DESCRIPTION
When using the AWS ALB Controller to automatically create a load-balancer for the ingress, I noticed that the chart does not allow a finalizer to be included for clean-up. This PR passes `ingress.finalizers` from the values.yaml through to the created ingress.