### PR TITLE
Change tls parameter default empty value from {} to [] in values.yaml

### DIFF
--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -190,7 +190,7 @@ ingress:
     {}
     # kubernetes.io/ingress.class: "nginx"
   path: /
-  tls: {}
+  tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local


### PR DESCRIPTION
The default empty value for `tls` parameter in `values.yaml` file is an empty object `{}` and should be a empty list `[]`:

This PR will change in the `values.yaml` file:
```
...
  tls: {}
...
```

for this:
```
...
  tls: []
...
```