### PR TITLE
feat: basic support for federation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Values.yaml
 
 
 **/.vim/
+cert-issuer.yaml
+pvc.yaml

--- a/rocketchat/Chart.yaml
+++ b/rocketchat/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
     condition: mongodb.enabled
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 16.x.x
+    version: x.x.x
     condition: postgresql.enabled
   - name: nats
     repository: https://nats-io.github.io/k8s/helm/charts

--- a/rocketchat/Chart.yaml
+++ b/rocketchat/Chart.yaml
@@ -7,6 +7,10 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 13.x.x
     condition: mongodb.enabled
+  - name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 16.x.x
+    condition: postgresql.enabled
   - name: nats
     repository: https://nats-io.github.io/k8s/helm/charts
     version: 0.15.x

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -131,6 +131,13 @@ The following table lists the configurable parameters of the Rocket.Chat chart a
 | `podDisruptionBudget.enabled`          | Enable or disable PDB for RC deployment                                                                                                                                                                                                                                                                                                                                                                                                                        | `true`                             |
 | `podLabels`                            | Additional pod labels for the Rocket.Chat pods                                                                                                                                                                                                                                                                                                                                                                                                                 | `{}`                               |
 | `podAnnotations`                       | Additional pod annotations for the Rocket.Chat pods                                                                                                                                                                                                                                                                                                                                                                                                            | `{}`                               |
+| `federation.enabled`                   | Enable Rocket.Chat federation (through matrix) 
+| `federation.host`                      | FQDN for your matrix instance
+| `federation.image.repository`          | Image repository to use for federation image, defaults to `matrixdotorg`
+| `federation.image.registry`            | Image registry to use for federation image, defaults to `docker.io`
+| `federation.image.tag`                 | Image tag to use for federation image, defaults to `latest`
+| `federation.persistence.enabled`       | Enabling persistence for matrix pod
+| `postgresql.enabled`                   | Enabling postgresql for matrix (synapse), defaults to true, if false, uses sqlite
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
@@ -205,6 +212,30 @@ data:
   mongo-oplog-uri: mongodb://user:password@localhost:27017/local?replicaSet=rs0&authSource=admin
 ```
 
+## Federation
+
+You can enable federation by setting `federation.enabled` to true.
+
+You need to make sure you have two domains, one for rocket.chat another for matrix.
+
+```yaml
+host: <rocket.chat domain>
+federation:
+    host: <matrix domain>
+```
+
+Add the domains to ingress tls config
+
+```yaml
+ingress:
+  tls:
+    - secretName: <some secret>
+      hosts:
+        - <rocket.chat domain>
+        - <matrix domain>
+```
+
+Since TLS is required, also make sure you have something like cert-manager is running on your cluster, and you add the annotations to the ingress with `ingress.annotations` (or whatever is the recommended way for your certificate issuer).
 
 ## Upgrading
 

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -143,6 +143,10 @@ spec:
 {{- with .Values.extraEnv }}
 	{{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
 {{- end }}
+        {{- if .Values.federation.enabled }}
+        - name: OVERWRITE_SETTING_Federation_Matrix_homeserver_domain
+          value: {{ .Values.host }}
+        {{end}}
         ports:
         - name: http
           containerPort: 3000
@@ -179,6 +183,10 @@ spec:
           mountPath: /app/uploads
         - name: tmp
           mountPath: /tmp
+        {{- if .Values.federation.enabled }}
+        - name: registration-config
+          mountPath: /app/matrix-federation-config
+        {{ end}}
         {{- if .Values.extraVolumeMounts }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}          
@@ -191,6 +199,11 @@ spec:
           claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "rocketchat.fullname" . }}{{- end }}
       {{- else }}
         emptyDir: {}
+      {{- if .Values.federation.enabled }}
+      - name: registration-config
+        configMap:
+          name: {{ template "rocketchat.fullname" . }}-synapse
+      {{end}}
       {{- end }}
       {{- if .Values.extraVolumes }}
       {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 6 }}

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -146,6 +146,34 @@ spec:
         {{- if .Values.federation.enabled }}
         - name: OVERWRITE_SETTING_Federation_Matrix_homeserver_domain
           value: {{ .Values.host }}
+        - name: OVERWRITE_SETTING_Federation_Matrix_enabled
+          value: "true"
+        - name: OVERWRITE_SETTING_serve_well_known
+          value: "false" {{/* TODO: prefer this over lighttpd */}}
+        - name: OVERWRITE_SETTING_id
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "rocketchat.fullname" . }}-synapse
+              key: appservice_id
+        - name: OVERWRITE_SETTING_hs_token
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "rocketchat.fullname" . }}-synapse
+              key: hs_token
+        - name: OVERWRITE_SETTING_as_token
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "rocketchat.fullname" . }}-synapse
+              key: as_token
+        - name: OVERWRITE_SETTING_bridge_url
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "rocketchat.fullname" . }}-synapse
+              key: bridge_url
+        - name: OVERWRITE_SETTING_homeserver_url
+          value: {{ template "rocketchat.fullname" . }}-synapse:8008
+        - name: OVERWRITE_SETTING_bridge_localpart
+          value: "rocket.cat"
         {{end}}
         ports:
         - name: http
@@ -183,10 +211,6 @@ spec:
           mountPath: /app/uploads
         - name: tmp
           mountPath: /tmp
-        {{- if .Values.federation.enabled }}
-        - name: registration-config
-          mountPath: /app/matrix-federation-config
-        {{ end}}
         {{- if .Values.extraVolumeMounts }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 8 }}
         {{- end }}          
@@ -199,11 +223,6 @@ spec:
           claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "rocketchat.fullname" . }}{{- end }}
       {{- else }}
         emptyDir: {}
-      {{- if .Values.federation.enabled }}
-      - name: registration-config
-        configMap:
-          name: {{ template "rocketchat.fullname" . }}-synapse
-      {{end}}
       {{- end }}
       {{- if .Values.extraVolumes }}
       {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 6 }}

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -156,22 +156,22 @@ spec:
           {{- end }}
         - name: OVERWRITE_SETTING_Federation_Matrix_id
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: appservice_id
         - name: OVERWRITE_SETTING_Federation_Matrix_hs_token
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: hs_token
         - name: OVERWRITE_SETTING_Federation_Matrix_as_token
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: as_token
         - name: OVERWRITE_SETTING_Federation_Matrix_bridge_url
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: bridge_url
         - name: OVERWRITE_SETTING_Federation_Matrix_homeserver_url

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -175,7 +175,7 @@ spec:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: bridge_url
         - name: OVERWRITE_SETTING_Federation_Matrix_homeserver_url
-          value: {{ template "rocketchat.fullname" . }}-synapse:8008
+          value: http://{{ template "rocketchat.fullname" . }}-synapse:8008
         - name: OVERWRITE_SETTING_Federation_Matrix_bridge_localpart
           value: "rocket.cat"
         {{end}}

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -149,7 +149,11 @@ spec:
         - name: OVERWRITE_SETTING_Federation_Matrix_enabled
           value: "true"
         - name: OVERWRITE_SETTING_serve_well_known
-          value: "false" {{/* TODO: prefer this over lighttpd */}}
+          {{- if not .Values.ingress.federation.serveWellKnown }}
+          value: "true"
+          {{- else }}
+          value: "false"
+          {{- end }}
         - name: OVERWRITE_SETTING_id
           valueFrom:
             configMapKeyRef:

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -148,35 +148,35 @@ spec:
           value: {{ .Values.host }}
         - name: OVERWRITE_SETTING_Federation_Matrix_enabled
           value: "true"
-        - name: OVERWRITE_SETTING_serve_well_known
+        - name: OVERWRITE_SETTING_Federation_Matrix_serve_well_known
           {{- if not .Values.ingress.federation.serveWellKnown }}
           value: "true"
           {{- else }}
           value: "false"
           {{- end }}
-        - name: OVERWRITE_SETTING_id
+        - name: OVERWRITE_SETTING_Federation_Matrix_id
           valueFrom:
             configMapKeyRef:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: appservice_id
-        - name: OVERWRITE_SETTING_hs_token
+        - name: OVERWRITE_SETTING_Federation_Matrix_hs_token
           valueFrom:
             configMapKeyRef:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: hs_token
-        - name: OVERWRITE_SETTING_as_token
+        - name: OVERWRITE_SETTING_Federation_Matrix_as_token
           valueFrom:
             configMapKeyRef:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: as_token
-        - name: OVERWRITE_SETTING_bridge_url
+        - name: OVERWRITE_SETTING_Federation_Matrix_bridge_url
           valueFrom:
             configMapKeyRef:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: bridge_url
-        - name: OVERWRITE_SETTING_homeserver_url
+        - name: OVERWRITE_SETTING_Federation_Matrix_homeserver_url
           value: {{ template "rocketchat.fullname" . }}-synapse:8008
-        - name: OVERWRITE_SETTING_bridge_localpart
+        - name: OVERWRITE_SETTING_Federation_Matrix_bridge_localpart
           value: "rocket.cat"
         {{end}}
         ports:

--- a/rocketchat/templates/ingress.yaml
+++ b/rocketchat/templates/ingress.yaml
@@ -59,7 +59,7 @@ spec:
             port:
               name: http
       {{- end }}
-      {{ if (and (and .Values.federation.enabled .Values.ingress.federation.serveWellKnown) (ne .Values.ingress.ingressClassName "nginx")) }}
+      {{ if (and (and .Values.federation.enabled .Values.ingress.federation.serveWellKnown) (ne .Values.ingress.ingressClassName "")) }}
       - path: /.well-known/matrix/server
         pathType: Prefix
         backend:

--- a/rocketchat/templates/ingress.yaml
+++ b/rocketchat/templates/ingress.yaml
@@ -59,7 +59,7 @@ spec:
             port:
               name: http
       {{- end }}
-      {{ if (and (and .Values.federation.enabled .Values.ingress.federation.serveWellKnown) (ne .Values.ingress.ingressClassName "")) }}
+      {{ if and .Values.federation.enabled .Values.ingress.federation.serveWellKnown) }}
       - path: /.well-known/matrix/server
         pathType: Prefix
         backend:

--- a/rocketchat/templates/ingress.yaml
+++ b/rocketchat/templates/ingress.yaml
@@ -59,4 +59,30 @@ spec:
             port:
               name: http
       {{- end }}
+  {{- if .Values.federation.enabled }}
+      - path: /.well-known/matrix/server
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "rocketchat.fullname" . }}-wellknown
+            port:
+              name: http
+      - path: /.well-known/matrix/client
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "rocketchat.fullname" . }}-wellknown
+            port:
+              name: http
+  - host: {{ .Values.federation.host }}
+    http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ template "rocketchat.fullname" . }}-synapse
+              port:
+                name: http
+    {{end}}
 {{- end }}

--- a/rocketchat/templates/ingress.yaml
+++ b/rocketchat/templates/ingress.yaml
@@ -59,7 +59,7 @@ spec:
             port:
               name: http
       {{- end }}
-  {{- if and .Values.federation.enabled .Values.ingress.federation.serveWellKnown }}
+      {{ if (and (and .Values.federation.enabled .Values.ingress.federation.serveWellKnown) (ne .Values.ingress.ingressClassName "nginx")) }}
       - path: /.well-known/matrix/server
         pathType: Prefix
         backend:

--- a/rocketchat/templates/ingress.yaml
+++ b/rocketchat/templates/ingress.yaml
@@ -59,7 +59,7 @@ spec:
             port:
               name: http
       {{- end }}
-  {{- if .Values.federation.enabled }}
+  {{- if and .Values.federation.enabled .Values.ingress.federation.serveWellKnown }}
       - path: /.well-known/matrix/server
         pathType: Prefix
         backend:

--- a/rocketchat/templates/lighttpd.yaml
+++ b/rocketchat/templates/lighttpd.yaml
@@ -1,4 +1,4 @@
-{{ if (and (and .Values.federation.enabled .Values.ingress.federation.serveWellKnown) (ne .Values.ingress.ingressClassName "nginx")) }}
+{{ if (and (and .Values.federation.enabled .Values.ingress.federation.serveWellKnown) (ne .Values.ingress.ingressClassName "")) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/rocketchat/templates/lighttpd.yaml
+++ b/rocketchat/templates/lighttpd.yaml
@@ -1,0 +1,93 @@
+{{ if .Values.federation.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "rocketchat.fullname" . }}-wellknown
+data:
+  lighttpd.conf: |
+    server.port = 8080
+    server.document-root = "/var/www/lighttpd"
+    server.modules = (
+      "mod_rewrite",
+      "mod_setenv"
+    )
+    url.rewrite-once     = (
+      "^/\.well-known/matrix/server" => "/server.json",
+      "^/\.well-known/matrix/client" => "/client.json"
+    )
+    setenv.add-response-header = (
+      "access-control-allow-methods" => "GET",
+      "access-control-allow-origin" => "*"
+    )
+    setenv.set-response-header = (
+      "content-type" => "application/json"
+    )
+
+  server.json: |
+    {{ dict "m.server" (printf "%s:443" .Values.federation.host) | toJson }}
+  client.json: |
+    {{ dict "m.homeserver" (dict "base_url" (printf "https://%s" .Values.federation.host)) | toJson }}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rocketchat.fullname" . }}-wellknown
+  labels:
+    app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-wellknown
+    helm.sh/chart: {{ include "rocketchat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-wellknown
+      helm.sh/chart: {{ include "rocketchat.chart" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-wellknown
+        helm.sh/chart: {{ include "rocketchat.chart" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+    spec:
+      containers:
+        - name: lighttpd
+          image: jitesoft/lighttpd
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/lighttpd/lighttpd.conf
+              name: files
+              subPath: lighttpd.conf
+            - mountPath: /var/www/lighttpd/server.json
+              name: files
+              subPath: server.json
+            - mountPath: /var/www/lighttpd/client.json
+              name: files
+              subPath: client.json
+      volumes:
+        - name: files
+          configMap:
+            name: {{ include "rocketchat.fullname" . }}-wellknown
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "rocketchat.fullname" . }}-wellknown
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app.kubernetes.io/name: {{ template "rocketchat.fullname" . }}-wellknown
+{{ end}}

--- a/rocketchat/templates/lighttpd.yaml
+++ b/rocketchat/templates/lighttpd.yaml
@@ -1,4 +1,4 @@
-{{ if (and (and .Values.federation.enabled .Values.ingress.federation.serveWellKnown) (ne .Values.ingress.ingressClassName "")) }}
+{{ if and .Values.federation.enabled .Values.ingress.federation.serveWellKnown) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/rocketchat/templates/lighttpd.yaml
+++ b/rocketchat/templates/lighttpd.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.federation.enabled }}
+{{ if (and (and .Values.federation.enabled .Values.ingress.federation.serveWellKnown) (ne .Values.ingress.ingressClassName "nginx")) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/rocketchat/templates/scripts-configmap.yaml
+++ b/rocketchat/templates/scripts-configmap.yaml
@@ -40,5 +40,102 @@ data:
     }
     quit(0);
   updateSynapseHomeserverConfig.sh: |
-    # TODO
+    _data_dir="${SYNAPSE_DATA_DIR:-/data}"
+    _data_dir="${_data_dir%/}"
+    _config_dir="${SYNAPSE_CONFIG_DIR:-/data}"
+    _config_dir="${_config_dir%/}"
+
+    start_or_exit() {
+      if [ "$1" = "--start" ]; then
+        exec /start.py
+      fi
+
+      exit 0
+    }
+
+    _remove_block() {
+      # local type="${1^^}"
+      local type="$(printf "%s" "$1" | tr '[[:lower]]' '[[:upper:]]')"
+      local file="$2"
+      local start="@@@ $type START @@@"
+      local end="@@@ $type END @@@"
+
+      local l1="$(awk "/$start/ {print NR; exit}" "$file")"
+      local l2="$(awk "/$end/ {print NR; exit}" "$file")"
+
+      if [ -z "$l1" -o -z "$l2" ]; then
+        return
+      fi
+
+      sed -i "${l1},${l2}d" $file
+    }
+
+    remove_extra_config() {
+      _remove_block "extra config" "HOMESERVER_YAML"
+    }
+
+    add_extra_config() {
+      if [ "$(tail -n 1 "$HOMESERVER" | base64)" != "Cg==" ]; then # `echo | base64`
+        printf "\n" >> "$HOMESERVER" 
+      fi
+
+      echo "@@@ EXTRA CONFIG START ($(basename $HOMESERVER_EXTRA_CONFIG)) @@@"
+      cat "$HOMESERVER_EXTRA_CONFIG" >> "$HOMESERVER"
+      echo "@@@ EXTRA CONFIG END ($(basename $HOMESERVER_EXTRA_CONFIG)) @@@"
+    }
+
+    hash() {
+      sha256sum "$1" | awk '{ print $2 }'
+    }
+
+    hash_file() {
+      local basename \
+            name \
+      basename="$(basename "$1")"
+      name=".${basename%.*}_hash"
+      echo -n "${_config_dir}/${name}"
+    }
+
+    extra_config_hash() {
+      hash "$HOMESERVER_EXTRA_CONFIG"
+    }
+
+    extra_config_current_hash() {
+      cat "$(hash_file "$HOMESERVER_EXTRA_CONFIG")"
+    }
+
+    _save_hash() {
+      hash "$1" > "$(hash_file "$1")"
+    }
+
+    save_extra_config_hash() {
+      _save_hash "$HOMESERVER_EXTRA_CONFIG"
+    }
+
+    HOMESERVER="${SYNAPSE_CONFIG_PATH:-$(ls "$_config_dir"/homeserver.y{a,}ml 2>/dev/null)}"
+
+    if [ -z "$HOMESERVER" -o ! -f "$HOMESERVER" ]; then
+      echo "homeserver config not found: \"$HOMESERVER\"" >&2
+      exit 1
+    fi
+
+    if [ -z "$HOMESERVER_EXTRA_CONFIG" ]; then
+      start_or_exit
+    fi
+
+    current_hash="$(extra_config_hash)"
+    expected_hash="$(extra_config_current_hash)"
+
+    if [ "$expected_hash" = "$current_hash" ]; then
+      echo "extra config hashes matched, ignoring append op."
+      exit 0
+    fi
+
+    echo "extra config hashes mismatch, re-setting extra config" >&2
+    remove_extra_config
+    add_extra_config
+    save_extra_config_hash
+
+    start_or_exit
+
 {{- end }}

--- a/rocketchat/templates/scripts-configmap.yaml
+++ b/rocketchat/templates/scripts-configmap.yaml
@@ -57,8 +57,8 @@ data:
       # local type="${1^^}"
       local type="$(printf "%s" "$1" | tr '[[:lower]]' '[[:upper:]]')"
       local file="$2"
-      local start="@@@ $type START @@@"
-      local end="@@@ $type END @@@"
+      local start="@@@ $type ($(basename $HOMESERVER_EXTRA_CONFIG)) START @@@"
+      local end="@@@ $type ($(basename $HOMESERVER_EXTRA_CONFIG)) END @@@"
 
       local l1="$(awk "/$start/ {print NR; exit}" "$file")"
       local l2="$(awk "/$end/ {print NR; exit}" "$file")"
@@ -71,7 +71,7 @@ data:
     }
 
     remove_extra_config() {
-      _remove_block "extra config" "HOMESERVER_YAML"
+      _remove_block "extra config" "$HOMESERVER"
     }
 
     add_extra_config() {

--- a/rocketchat/templates/scripts-configmap.yaml
+++ b/rocketchat/templates/scripts-configmap.yaml
@@ -39,4 +39,6 @@ data:
       quit(1);
     }
     quit(0);
+  updateSynapseHomeserverConfig.sh: |
+    # TODO
 {{- end }}

--- a/rocketchat/templates/scripts-configmap.yaml
+++ b/rocketchat/templates/scripts-configmap.yaml
@@ -40,6 +40,12 @@ data:
     }
     quit(0);
   updateSynapseHomeserverConfig.sh: |
+    [[ $(basename $SHELL) != "bash" ]] && {
+      echo "must be run in bash"
+      exit 1
+    } || :
+
+    set -x
     _data_dir="${SYNAPSE_DATA_DIR:-/data}"
     _data_dir="${_data_dir%/}"
     _config_dir="${SYNAPSE_CONFIG_DIR:-/data}"
@@ -54,8 +60,8 @@ data:
     }
 
     _remove_block() {
-      # local type="${1^^}"
-      local type="$(printf "%s" "$1" | tr '[[:lower]]' '[[:upper:]]')"
+      local type="${1^^}"
+      #local type="$(printf "%s" "$1" | tr '[[:lower:]]' '[[:upper:]]')"
       local file="$2"
       local start="@@@ $type ($(basename $HOMESERVER_EXTRA_CONFIG)) START @@@"
       local end="@@@ $type ($(basename $HOMESERVER_EXTRA_CONFIG)) END @@@"
@@ -79,13 +85,13 @@ data:
         printf "\n" >> "$HOMESERVER" 
       fi
 
-      echo "@@@ EXTRA CONFIG START ($(basename $HOMESERVER_EXTRA_CONFIG)) @@@"
+      echo "# @@@ EXTRA CONFIG START ($(basename $HOMESERVER_EXTRA_CONFIG)) @@@" >>"$HOMESERVER"
       cat "$HOMESERVER_EXTRA_CONFIG" >> "$HOMESERVER"
-      echo "@@@ EXTRA CONFIG END ($(basename $HOMESERVER_EXTRA_CONFIG)) @@@"
+      echo "# @@@ EXTRA CONFIG END ($(basename $HOMESERVER_EXTRA_CONFIG)) @@@" >>"$HOMESERVER"
     }
 
     hash() {
-      sha256sum "$1" | awk '{ print $2 }'
+      sha256sum "$1" | awk '{ print $1 }'
     }
 
     hash_file() {
@@ -101,6 +107,7 @@ data:
     }
 
     extra_config_current_hash() {
+      [[ -f "$(hash_file "$HOMESERVER_EXTRA_CONFIG")" ]] || return ""
       cat "$(hash_file "$HOMESERVER_EXTRA_CONFIG")"
     }
 

--- a/rocketchat/templates/service.yaml
+++ b/rocketchat/templates/service.yaml
@@ -48,3 +48,25 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "rocketchat.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+---
+{{ if .Values.federation.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "rocketchat.fullname" . }}-bridge
+  labels:
+    app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-bridge
+    helm.sh/chart: {{ include "rocketchat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 3300
+    targetPort: 3300
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "rocketchat.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{end}}

--- a/rocketchat/templates/synapse.yaml
+++ b/rocketchat/templates/synapse.yaml
@@ -4,10 +4,11 @@
 {{- $bridge_url :=  printf "http://%s-bridge:3300" (include "rocketchat.fullname" .) -}}
 {{- $id := randAlphaNum 14 | b64enc | printf "rocketchat_%s" -}}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ include "rocketchat.fullname" . }}-synapse
-data:
+
+stringData:
   as_token: {{ $as_token }}
   hs_token: {{ $hs_token }}
   bridge_url: {{ $bridge_url }}
@@ -25,6 +26,28 @@ data:
 
     allow_public_rooms_without_auth: true
     allow_public_rooms_over_federation: true
+
+  {{- if .Values.postgresql.enabled }}
+
+  {{- if (not (and (include "postgresql.v1.createSecret" .Subcharts.postgresql) .Values.federation.extraConfigSecretName) }}
+  {{- fail "postgres password must be in values.yaml or passed through federation.extraConfigSecretName" }}
+  {{- end }}
+
+    {{- if not (include "postgresql.v1.createSecret" .Subcharts.postgresql) }}
+    database:
+      name: psycopg2
+      args:
+        {{- if .Values.postgresql.auth.enabled }}
+        user: {{ include "postgresql.v1.username" .Subcharts.postgresql }}
+        password: {{ .Values.postgresql.auth.password }} {{/* FIXME(debdut): this needs to be better, https://github.com/bitnami/charts/blob/8edf559ce9db3515aad61f5c8cb261b1c19bc93a/bitnami/postgresql/templates/secrets.yaml#L23 */}}
+        {{- end }}
+        database: {{ include "postgresql.v1.database" .Subcharts.postgresql }}
+        host: {{ include "postgresql.v1.primary.svc.headless" .Subcharts.postgresql }} 
+        cp_min: 5
+        cp_max: 10
+    {{- end }}
+
+  {{- end }}
 
   registration.yaml: |
     id: {{ $id }}
@@ -80,16 +103,29 @@ spec:
               value: 'no'
         - name: append
           image: matrixdotorg/synapse:v1.78.0
+          env:
+            - name: HOMESERVER_APPEND_FILE
+              value: /homeserver.append.yaml
+              {{- if .Values.federation.extraConfigSecretName }}
+            - name: HOMESERVER_EXTRA_CONFIG
+              value: /homeserver.extra.yaml
+              {{- end }}
           volumeMounts:
+          - name: scripts
+            mountPath: /scripts
           - name: data
             mountPath: /data
           - name: config
             mountPath: /homeserver.append.yaml
             subPath: homeserver.append.yaml
+          {{- if .Values.federation.extraConfigSecretName }}
+          - name: extraConfig
+            mountPath: /homeserver.extra.yaml
+            subPath: homeserver.extra.yaml 
+          {{- end }}
           command:
             - sh
-            - -c
-            - 'echo >> /data/homeserver.yaml && cat /homeserver.append.yaml >> /data/homeserver.yaml'
+            - /scripts/updateSynapseHomeserverConfig.sh
       containers:
       - image: matrixdotorg/synapse:v1.78.0
         name: synapse
@@ -102,9 +138,17 @@ spec:
         ports:
           - containerPort: 8008
       volumes:
-      - name: config
+      - name: scripts
         configMap:
-          name: {{ template "rocketchat.fullname" . }}-synapse
+          name: {{ template "rocketchat.fullname" . }}-scripts
+      - name: config
+        secret:
+          secretName: {{ template "rocketchat.fullname" . }}-synapse
+      {{- with .Values.federation.extraConfigSecretName }}
+      - name: extraConfig
+        secret:
+          secretName: {{ . | quote }}
+      {{- end }}
       - name: data
         {{- if .Values.federation.persistence.enabled }}
         persistentVolumeClaim:

--- a/rocketchat/templates/synapse.yaml
+++ b/rocketchat/templates/synapse.yaml
@@ -1,0 +1,130 @@
+{{ if .Values.federation.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "rocketchat.fullname" . }}-synapse
+data:
+  homeserver.append.yaml: |
+    app_service_config_files:
+      - /registration.yaml
+
+    retention:
+      enabled: true
+
+    enable_registration: true
+    enable_registration_without_verification: true
+    suppress_key_server_warning: true
+
+    allow_public_rooms_without_auth: true
+    allow_public_rooms_over_federation: true
+
+  registration.yaml: |
+    id: rocketchat_{{ randAlphaNum 14 | b64enc }}
+    hs_token: {{ randAlphaNum 26 | b64enc | quote }}
+    as_token: {{ randAlphaNum 26 | b64enc | quote }}
+    url: http://{{ template "rocketchat.fullname" . }}-bridge:3300
+    sender_localpart: rocket.cat
+    namespaces:
+      users:
+        - exclusive: false
+          regex: .*
+      rooms:
+        - exclusive: false
+          regex: .*
+      aliases:
+        - exclusive: false
+          regex: .*
+    de.sorunome.msc2409.push_ephemeral: false
+    rocketchat:
+      homeserver_url: http://{{ template "rocketchat.fullname" . }}-synapse:8008 
+      homeserver_domain: {{ .Values.host }}
+---
+apiVersion: {{ template "deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "rocketchat.fullname" . }}-synapse
+  labels:
+    app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-synapse
+    helm.sh/chart: {{ include "rocketchat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-synapse
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-synapse
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      initContainers:
+        - name: generate
+          image: matrixdotorg/synapse:v1.78.0
+          volumeMounts:
+          - name: data
+            mountPath: /data
+          command: ["/start.py", 'generate']
+          env:
+            - name: SYNAPSE_SERVER_NAME
+              value: {{ .Values.host }}
+            - name: SYNAPSE_REPORT_STATS
+              value: 'no'
+        - name: append
+          image: matrixdotorg/synapse:v1.78.0
+          volumeMounts:
+          - name: data
+            mountPath: /data
+          - name: config
+            mountPath: /homeserver.append.yaml
+            subPath: homeserver.append.yaml
+          command:
+            - sh
+            - -c
+            - 'echo >> /data/homeserver.yaml && cat /homeserver.append.yaml >> /data/homeserver.yaml'
+      containers:
+      - image: matrixdotorg/synapse:v1.78.0
+        name: synapse
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        - name: config
+          mountPath: /registration.yaml
+          subPath: registration.yaml
+        ports:
+          - containerPort: 8008
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "rocketchat.fullname" . }}-synapse
+      - name: data
+        {{- if .Values.federation.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ if .Values.federation.persistence.existingClaim }}{{ .Values.federation.persistence.existingClaim }}{{- else }}{{ template "rocketchat.fullname" . }}-synapse {{- end }} 
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "rocketchat.fullname" . }}-synapse
+  labels:
+    app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-synapse
+    helm.sh/chart: {{ include "rocketchat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8008
+    targetPort: 8008
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-synapse
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}

--- a/rocketchat/templates/synapse.yaml
+++ b/rocketchat/templates/synapse.yaml
@@ -1,9 +1,17 @@
 {{ if .Values.federation.enabled }}
+{{- $hs_token := randAlphaNum 26 | b64enc | quote -}}
+{{- $as_token := randAlphaNum 24 | b64enc | quote -}}
+{{- $bridge_url :=  printf "http://%s-bridge:3300" (include "rocketchat.fullname" .) -}}
+{{- $id := randAlphaNum 14 | b64enc | printf "rocketchat_%s" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "rocketchat.fullname" . }}-synapse
 data:
+  as_token: {{ $as_token }}
+  hs_token: {{ $hs_token }}
+  bridge_url: {{ $bridge_url }}
+  appservice_id: {{ $id }}
   homeserver.append.yaml: |
     app_service_config_files:
       - /registration.yaml
@@ -19,10 +27,10 @@ data:
     allow_public_rooms_over_federation: true
 
   registration.yaml: |
-    id: rocketchat_{{ randAlphaNum 14 | b64enc }}
-    hs_token: {{ randAlphaNum 26 | b64enc | quote }}
-    as_token: {{ randAlphaNum 26 | b64enc | quote }}
-    url: http://{{ template "rocketchat.fullname" . }}-bridge:3300
+    id: {{ $id }}
+    hs_token: {{ $hs_token }}
+    as_token: {{ $as_token }}
+    url: {{ $bridge_url }}
     sender_localpart: rocket.cat
     namespaces:
       users:
@@ -35,9 +43,6 @@ data:
         - exclusive: false
           regex: .*
     de.sorunome.msc2409.push_ephemeral: false
-    rocketchat:
-      homeserver_url: http://{{ template "rocketchat.fullname" . }}-synapse:8008 
-      homeserver_domain: {{ .Values.host }}
 ---
 apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment

--- a/rocketchat/templates/synapse.yaml
+++ b/rocketchat/templates/synapse.yaml
@@ -127,4 +127,29 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-synapse
     app.kubernetes.io/instance: {{ .Release.Name }}
+---
+{{- if (and .Values.federation.persistence.enabled (not .Values.federation.persistence.existingClaim)) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+
+metadata:
+  name: {{ template "rocketchat.fullname" . }}-synapse
+  labels:
+    app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-synapse
+    helm.sh/chart: {{ include "rocketchat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+
+spec:
+  {{- if .Values.federation.persistence.storageClassName }}
+  storageClassName: {{ .Values.federation.persistence.storageClassName }}
+  {{ end }}
+  accessModes:
+    {{- range .Values.federation.persistence.accessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.federation.persistence.resources.requests.storage | default "10Gi" }}
+{{- end -}}
 {{ end }}

--- a/rocketchat/templates/synapse.yaml
+++ b/rocketchat/templates/synapse.yaml
@@ -104,37 +104,39 @@ spec:
         - name: append
           image: matrixdotorg/synapse:v1.78.0
           env:
-            - name: HOMESERVER_APPEND_FILE
-              value: /homeserver.append.yaml
-              {{- if .Values.federation.extraConfigSecretName }}
             - name: HOMESERVER_EXTRA_CONFIG
-              value: /homeserver.extra.yaml
-              {{- end }}
+              value: /__homeserver.append.yaml
           volumeMounts:
           - name: scripts
             mountPath: /scripts
           - name: data
             mountPath: /data
           - name: config
-            mountPath: /homeserver.append.yaml
+            mountPath: /__homeserver.append.yaml
             subPath: homeserver.append.yaml
-          {{- if .Values.federation.extraConfigSecretName }}
-          - name: extraConfig
-            mountPath: /homeserver.extra.yaml
-            subPath: homeserver.extra.yaml 
-          {{- end }}
           command:
             - sh
             - /scripts/updateSynapseHomeserverConfig.sh
       containers:
       - image: matrixdotorg/synapse:v1.78.0
         name: synapse
+        env:
+          {{- if .Values.federation.extraConfigSecretName }}
+          - name: HOMESERVER_EXTRA_CONFIG
+            value: /homeserver.extra.yaml
+        command:
+          - sh
+          - /scripts/updateSynapseHomeserverConfig.sh
+          - --start
+          {{- end }}
         volumeMounts:
         - name: data
           mountPath: /data
         - name: config
           mountPath: /registration.yaml
           subPath: registration.yaml
+        - name: scripts
+          mountPath: /scripts
         ports:
           - containerPort: 8008
       volumes:

--- a/rocketchat/templates/synapse.yaml
+++ b/rocketchat/templates/synapse.yaml
@@ -88,7 +88,8 @@ spec:
     spec:
       initContainers:
         - name: generate
-          image: matrixdotorg/synapse:v1.78.0
+          #image: matrixdotorg/synapse:v1.78.0
+          image: {{ default "docker.io" .Values.federation.image.registry }}/{{ default "matrixdotorg" .Values.federation.image.repository }}:{{ default "latest" .Values.federation.image.tag }}
           volumeMounts:
           - name: data
             mountPath: /data

--- a/rocketchat/templates/synapse.yaml
+++ b/rocketchat/templates/synapse.yaml
@@ -29,23 +29,20 @@ stringData:
 
   {{- if .Values.postgresql.enabled }}
 
-  {{- if (not (and (include "postgresql.v1.createSecret" .Subcharts.postgresql) .Values.federation.extraConfigSecretName) }}
+  {{- if (not (or (include "postgresql.v1.createSecret" .Subcharts.postgresql) .Values.federation.extraConfigSecret)) }}
   {{- fail "postgres password must be in values.yaml or passed through federation.extraConfigSecretName" }}
   {{- end }}
 
-    {{- if not (include "postgresql.v1.createSecret" .Subcharts.postgresql) }}
     database:
       name: psycopg2
       args:
-        {{- if .Values.postgresql.auth.enabled }}
         user: {{ include "postgresql.v1.username" .Subcharts.postgresql }}
         password: {{ .Values.postgresql.auth.password }} {{/* FIXME(debdut): this needs to be better, https://github.com/bitnami/charts/blob/8edf559ce9db3515aad61f5c8cb261b1c19bc93a/bitnami/postgresql/templates/secrets.yaml#L23 */}}
-        {{- end }}
         database: {{ include "postgresql.v1.database" .Subcharts.postgresql }}
         host: {{ include "postgresql.v1.primary.svc.headless" .Subcharts.postgresql }} 
         cp_min: 5
         cp_max: 10
-    {{- end }}
+      allow_unsafe_locale: true
 
   {{- end }}
 
@@ -115,7 +112,7 @@ spec:
             mountPath: /__homeserver.append.yaml
             subPath: homeserver.append.yaml
           command:
-            - sh
+            - bash
             - /scripts/updateSynapseHomeserverConfig.sh
       containers:
       - image: matrixdotorg/synapse:v1.78.0
@@ -125,7 +122,7 @@ spec:
           - name: HOMESERVER_EXTRA_CONFIG
             value: /homeserver.extra.yaml
         command:
-          - sh
+          - bash
           - /scripts/updateSynapseHomeserverConfig.sh
           - --start
           {{- end }}

--- a/rocketchat/templates/synapse.yaml
+++ b/rocketchat/templates/synapse.yaml
@@ -121,7 +121,7 @@ spec:
       - image: matrixdotorg/synapse:v1.78.0
         name: synapse
         env:
-          {{- if .Values.federation.extraConfigSecretName }}
+          {{- if .Values.federation.extraConfigSecret }}
           - name: HOMESERVER_EXTRA_CONFIG
             value: /homeserver.extra.yaml
         command:
@@ -137,6 +137,11 @@ spec:
           subPath: registration.yaml
         - name: scripts
           mountPath: /scripts
+        {{- with .Values.federation.extraConfigSecret }}
+        - name: extraConfig
+          mountPath: /homeserver.extra.yaml
+          subPath: {{ .key | quote }}
+        {{- end }}
         ports:
           - containerPort: 8008
       volumes:
@@ -146,10 +151,10 @@ spec:
       - name: config
         secret:
           secretName: {{ template "rocketchat.fullname" . }}-synapse
-      {{- with .Values.federation.extraConfigSecretName }}
+      {{- with .Values.federation.extraConfigSecret }}
       - name: extraConfig
         secret:
-          secretName: {{ . | quote }}
+          secretName: {{ .name | quote }}
       {{- end }}
       - name: data
         {{- if .Values.federation.persistence.enabled }}

--- a/rocketchat/templates/synapse.yaml
+++ b/rocketchat/templates/synapse.yaml
@@ -1,4 +1,9 @@
-{{ if .Values.federation.enabled }}
+{{- if .Values.federation.enabled }}
+{{- if not .Values.federation.ignoreRocketChatVersion }} {{/* this can be removed at any point, used just for testing */}}
+{{- if (eq (semver "6.6.4" | (semver .Chart.AppVersion).Compare) -1) }}
+{{- fail "federation must be used with rocket.chat version >= 6.6.4" }}
+{{- end }}
+{{- end }}
 {{- $hs_token := randAlphaNum 26 | b64enc | quote -}}
 {{- $as_token := randAlphaNum 24 | b64enc | quote -}}
 {{- $bridge_url :=  printf "http://%s-bridge:3300" (include "rocketchat.fullname" .) -}}

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -338,10 +338,11 @@ nats:
     image: nats:2.4-alpine
 
 federation:
+  # host:
   image:
-    repository:
-    registry:
-    tag:
+    repository: matrixdotorg
+    registry: docker.io
+    tag: latest
   enabled: false
   persistence:
     enabled: false

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -337,3 +337,11 @@ nats:
 
 federation:
   enabled: false
+  persistence:
+    enabled: false
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -334,3 +334,6 @@ microservices:
 nats:
   nats:
     image: nats:2.4-alpine
+
+federation:
+  enabled: false

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -338,6 +338,10 @@ nats:
     image: nats:2.4-alpine
 
 federation:
+  image:
+    repository:
+    registry:
+    tag:
   enabled: false
   persistence:
     enabled: false
@@ -347,3 +351,5 @@ federation:
       requests:
         storage: 10Gi
 
+postgresql:
+  enabled: true

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -194,6 +194,8 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  federation:
+    serveWellKnown: false # if false, rocket.chat will handle the response
 
 service:
   annotations: {}

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -195,7 +195,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
   federation:
-    serveWellKnown: false # if false, rocket.chat will handle the response
+    serveWellKnown: true # if false, rocket.chat will handle the response
 
 service:
   annotations: {}
@@ -353,3 +353,7 @@ federation:
 
 postgresql:
   enabled: true
+  primary:
+    extraEnvVars:
+      - name: POSTGRES_INITDB_ARGS
+        value: "--lc-collate=C --lc-ctype=C"


### PR DESCRIPTION
This is a very basic support to quickly enable federation in your deployment. 

To configure the deployment, add the following to the values file -

```yaml
host: ... # this is a must for federation as https is required
ingress:
  enabled: true
  annotations:
    cert-manager.io/cluster-issuer: some-issuer # or some other annotation if using annotation based automatic certificate assignment
  tls:
    hosts:
      - ... # the value of host
      - ... # value of the domain where matrix will be accessible from

federation:
  enabled: true
  host: ... # some host where your synapse install will be accessible from
  persistence:
    enabled: true
    existingClaim: ... # some claim
```
