### PR TITLE
add extra secret for chat deployment

### DIFF
--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -56,6 +56,11 @@ spec:
       - name: rocketchat
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.extraSecret.enabled }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.extraSecret.name }}
+        {{- end }}
         env:
         - name: DEPLOY_PLATFORM
           value: helm-chart

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -29,7 +29,8 @@ extraEnv:
   #   value: mongodb://oploguser:password@rocket-1:27017/local&replicaSet=rs0
 
 # Extra secret for Rocket.Chat
-# Usefull to store sensitive data for creating initial user (e.g. ADMIN_* env vars) or custom OAUTH settings (e.g. Accounts_OAuth_Custom_* env vars)
+# Usefull to store sensitive data for creating initial user (e.g. ADMIN_* env vars) 
+# or custom OAUTH settings (e.g. Accounts_OAuth_Custom_* env vars)
 extraSecret:
   enabled: false
   name: ""

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -28,6 +28,12 @@ extraEnv:
   # - name: MONGO_OPLOG_URL
   #   value: mongodb://oploguser:password@rocket-1:27017/local&replicaSet=rs0
 
+# Extra secret for Rocket.Chat
+# Usefull to store sensitive data for creating initial user (e.g. ADMIN_* env vars) or custom OAUTH settings (e.g. Accounts_OAuth_Custom_* env vars)
+extraSecret:
+  enabled: false
+  name: ""
+
 # Extra volumes for Rocket.Chat...
 extraVolumes:
   # - name: etc-certs


### PR DESCRIPTION
Add extra secret for chat deployment.
Usefull to store sensitive data for creating initial user like ADMIN_* env vars or custom OAUTH settings like Accounts_OAuth_Custom_* env vars.