### PR TITLE
fix: missing imagePullSecrets from rocketchat-pre-upgrade job

### DIFF
--- a/rocketchat/templates/hook-verify-mongodb-version.yaml
+++ b/rocketchat/templates/hook-verify-mongodb-version.yaml
@@ -37,6 +37,10 @@ spec:
             - sh
             - -c
             - 'mongosh "$MONGODB_HOST" /tmp/verifyMongodb.js {{ .Values.mongodb.image.tag }}'
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       volumes:
         - name: mongodb-script
           configMap:


### PR DESCRIPTION
rocketchat-pre-upgrade job cannot use private registries because the imagePullSecrets is missing.