### PR TITLE
feat: serve well-known paths for federation natively

### DIFF
--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -309,3 +309,11 @@ Refernces:
 - [Run a shell inside a container (to check mongodb version)](https://kubernetes.io/docs/tasks/debug/debug-application/get-shell-running-container/)
 - [MongoDB upgrade official documentation](https://www.mongodb.com/docs/manual/tutorial/upgrade-revision/)
 - [MongoDB helm chart options](https://artifacthub.io/packages/helm/bitnami/mongodb)
+
+### To 6.13.0
+
+**This is only applicable if you both, enabled federation in chart version >=6.8, and want to keep using lighttpd.**
+
+During upgrade, disable `ingress.federation.serveWellKnown` once before enabling it again.
+
+Chart contained a bug that would cause `wellknown` deployment to fail to update (illegal live modification of `matchLables`).

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -314,6 +314,6 @@ Refernces:
 
 **This is only applicable if you both, enabled federation in chart version >=6.8, and want to keep using lighttpd.**
 
-During upgrade, disable `ingress.federation.serveWellKnown` once before enabling it again.
+IFF you manually enabled ingress.federation.serveWellKnown (which was a hidden setting) before, during upgrade, disable it once before enabling it again.
 
 Chart contained a bug that would cause `wellknown` deployment to fail to update (illegal live modification of `matchLables`).

--- a/rocketchat/templates/lighttpd.yaml
+++ b/rocketchat/templates/lighttpd.yaml
@@ -43,16 +43,12 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-wellknown
-      helm.sh/chart: {{ include "rocketchat.chart" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-wellknown
-        helm.sh/chart: {{ include "rocketchat.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
     spec:
       containers:
         - name: lighttpd

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -205,7 +205,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
   federation:
-    serveWellKnown: true # if false, rocket.chat will handle the response
+    serveWellKnown: false
 
 service:
   annotations: {}


### PR DESCRIPTION
### Upgrading To 6.13 from >=6.8

**This is only applicable if you both, enabled federation in chart version >=6.8, and want to keep using lighttpd (no longer required, neither is the default anymore).**

IFF you manually enabled `ingress.federation.serveWellKnown` (which was a hidden setting) before, during upgrade, disable it  once before enabling it again.

DPLOY-75