### PR TITLE
feat: serve well-known paths for federation natively 

### DIFF
--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -314,6 +314,6 @@ Refernces:
 
 **This is only applicable if you both, enabled federation in chart version >=6.8, and want to keep using lighttpd.**
 
-IFF you manually enabled ingress.federation.serveWellKnown (which was a hidden setting) before, during upgrade, disable it once before enabling it again.
+IFF you manually enabled `ingress.federation.serveWellKnown` (which was a hidden setting) before, during upgrade, disable it once before enabling it again.
 
-Chart contained a bug that would cause `wellknown` deployment to fail to update (illegal live modification of `matchLables`).
+Chart contained a bug that would cause `wellknown` deployment to fail to update (illegal live modification of `matchLabels`).

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -180,7 +180,11 @@ spec:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: bridge_url
         - name: OVERWRITE_SETTING_Federation_Matrix_homeserver_url
+          {{- if .Values.ingress.federation.serveWellKnown }}
           value: http://{{ template "rocketchat.fullname" . }}-synapse:8008
+          {{- else }}
+          value: https://{{ .Values.federation.host }}
+          {{- end }}
         - name: OVERWRITE_SETTING_Federation_Matrix_bridge_localpart
           value: "rocket.cat"
         {{end}}


### PR DESCRIPTION
### Upgrading To 6.13 from >=6.8

**This is only applicable if you both, enabled federation in chart version >=6.8, and want to keep using lighttpd (no longer required, neither is the default anymore).**

IFF you manually enabled `ingress.federation.serveWellKnown` (which was a hidden setting) before, during upgrade, disable it  once before enabling it again.

DPLOY-75