### PR TITLE
feat: serve well-known paths for federation natively 

### DIFF
--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -305,7 +305,15 @@ mongodb:
     tag: # find from https://hub.docker.com/r/bitnami/mongodb/tags
 ```
 
-Refernces:
+References:
 - [Run a shell inside a container (to check mongodb version)](https://kubernetes.io/docs/tasks/debug/debug-application/get-shell-running-container/)
 - [MongoDB upgrade official documentation](https://www.mongodb.com/docs/manual/tutorial/upgrade-revision/)
 - [MongoDB helm chart options](https://artifacthub.io/packages/helm/bitnami/mongodb)
+
+### To 6.13.0
+
+**This is only applicable if you both, enabled federation in chart version >=6.8, and want to keep using lighttpd.**
+
+IFF you manually enabled ingress.federation.serveWellKnown (which was a hidden setting) before, during upgrade, disable it once before enabling it again.
+
+Chart contained a bug that would cause `wellknown` deployment to fail to update (illegal live modification of `matchLabels`).

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -180,7 +180,11 @@ spec:
               name: {{ include "rocketchat.fullname" . }}-synapse
               key: bridge_url
         - name: OVERWRITE_SETTING_Federation_Matrix_homeserver_url
+         {{- if .Values.ingress.federation.serveWellKnown }}
           value: http://{{ template "rocketchat.fullname" . }}-synapse:8008
+          {{- else }}
+          value: https://{{ .Values.federation.host }}
+          {{- end }} 
         - name: OVERWRITE_SETTING_Federation_Matrix_bridge_localpart
           value: "rocket.cat"
         {{end}}

--- a/rocketchat/templates/ingress.yaml
+++ b/rocketchat/templates/ingress.yaml
@@ -59,7 +59,8 @@ spec:
             port:
               name: http
       {{- end }}
-      {{ if and .Values.federation.enabled .Values.ingress.federation.serveWellKnown }}
+      {{- if .Values.federation.enabled }}
+      {{- if .Values.ingress.federation.serveWellKnown }}
       - path: /.well-known/matrix/server
         pathType: Prefix
         backend:
@@ -74,6 +75,7 @@ spec:
             name: {{ template "rocketchat.fullname" . }}-wellknown
             port:
               name: http
+      {{- end }}
   - host: {{ .Values.federation.host }}
     http:
       paths:

--- a/rocketchat/templates/lighttpd.yaml
+++ b/rocketchat/templates/lighttpd.yaml
@@ -35,17 +35,13 @@ metadata:
   name: {{ include "rocketchat.fullname" . }}-wellknown
   labels:
     app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-wellknown
-    helm.sh/chart: {{ include "rocketchat.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "rocketchat.fullname" . }}-wellknown
-      helm.sh/chart: {{ include "rocketchat.chart" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
   template:
     metadata:
       labels:

--- a/rocketchat/templates/synapse.yaml
+++ b/rocketchat/templates/synapse.yaml
@@ -4,14 +4,29 @@
 {{- fail "federation must be used with rocket.chat version >= 6.6.4" }}
 {{- end }}
 {{- end }}
-{{- $hs_token := randAlphaNum 26 | b64enc | quote -}}
-{{- $as_token := randAlphaNum 24 | b64enc | quote -}}
+{{- $secret := include "rocketchat.fullname" . | printf "%s-synapse" | lookup "v1" "Secret" .Release.Namespace }}
+{{- $hs_token := "" }}
+{{- $as_token := "" }}
 {{- $bridge_url :=  printf "http://%s-bridge:3300" (include "rocketchat.fullname" .) -}}
-{{- $id := randAlphaNum 14 | b64enc | printf "rocketchat_%s" -}}
+{{- $id := "" }}
+{{- if $secret }}
+{{- $hs_token = $secret.data.hs_token | b64dec -}}
+{{- $as_token = $secret.data.as_token | b64dec -}}
+{{- $id = $secret.data.appservice_id | b64dec -}}
+{{- else }}
+{{- $hs_token = randAlphaNum 26 | b64enc | quote -}}
+{{- $as_token = randAlphaNum 24 | b64enc | quote -}}
+{{- $id = randAlphaNum 14 | b64enc | printf "rocketchat_%s" -}}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "rocketchat.fullname" . }}-synapse
+  labels:
+    app.kubernetes.io/name: {{ include "rocketchat.name" . }}-synapse
+    helm.sh/chart: {{ include "rocketchat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 stringData:
   as_token: {{ $as_token }}

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -205,7 +205,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
   federation:
-    serveWellKnown: true # if false, rocket.chat will handle the response
+    serveWellKnown: false
 
 service:
   annotations: {}


### PR DESCRIPTION
### Upgrading To 6.13 from >=6.8

**This is only applicable if you both, enabled federation in chart version >=6.8, and want to keep using lighttpd (no longer required, neither is the default anymore).**

IFF you manually enabled `ingress.federation.serveWellKnown` (which was a hidden setting) before, during upgrade, disable it  once before enabling it again.

DPLOY-75