### PR TITLE
Map Pod Annotations to All Pods

### DIFF
--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -113,6 +113,7 @@ The following table lists the configurable parameters of the Rocket.Chat chart a
 | `livenessProbe.failureThreshold`       | Minimum consecutive failures for the probe                                                                                                                                                                                                                                                                                                                                                                                                                     | `3`                                |
 | `livenessProbe.successThreshold`       | Minimum consecutive successes for the probe                                                                                                                                                                                                                                                                                                                                                                                                                    | `1`                                |
 | `global.tolerations`                   | common tolerations for all pods (rocket.chat and all microservices) | []  |
+| `global.annotations`                   | common annotations for all pods (rocket.chat and all microservices) | {}  |
 | `tolerations`                          | tolerations for main rocket.chat pods (the `meteor` service) | [] |
 | `microservices.enabled`                | Use [microservices](https://docs.rocket.chat/quick-start/installing-and-updating/micro-services-setup-beta) architecture                                                                                                                                                                                                                                                                                                                                       | `false`                            |
 | `microservices.presence.replicas`      | Number of replicas to run for the given service                                                                                                                                                                                                                                                                                                                                                                                                                | `1`                                |
@@ -120,12 +121,17 @@ The following table lists the configurable parameters of the Rocket.Chat chart a
 | `microservices.streamHub.replicas`     | Idem                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
 | `microservices.accounts.replicas`      | Idem                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
 | `microservices.authorization.replicas` | Idem                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
-| `microservices.presence.tolerations`      | Pod tolerations | [] |
-| `microservices.ddpStreamer.tolerations`      | Pod tolerations | [] |
-| `microservices.streamHub.tolerations`      | Pod tolerations | [] |
-| `microservices.accounts.tolerations`      | Pod tolerations | [] |
-| `microservices.authorization.tolerations`      | Pod tolerations | [] |
 | `microservices.nats.replicas`          | Idem                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
+| `microservices.presence.tolerations`      | Pod tolerations | [] |
+| `microservices.ddpStreamer.tolerations`   | Pod tolerations | [] |
+| `microservices.streamHub.tolerations`     | Pod tolerations | [] |
+| `microservices.accounts.tolerations`      | Pod tolerations | [] |
+| `microservices.authorization.tolerations` | Pod tolerations | [] |
+| `microservices.presence.annotations`      | Pod annotations | {} |
+| `microservices.ddpStreamer.annotations`   | Pod annotations | {} |
+| `microservices.streamHub.annotations`     | Pod annotations | {} |
+| `microservices.accounts.annotations`      | Pod annotations | {} |
+| `microservices.authorization.annotations` | Pod annotations | {} |
 | `readinessProbe.enabled`               | Turn on and off readiness probe                                                                                                                                                                                                                                                                                                                                                                                                                                | `true`                             |
 | `readinessProbe.initialDelaySeconds`   | Delay before readiness probe is initiated                                                                                                                                                                                                                                                                                                                                                                                                                      | `10`                               |
 | `readinessProbe.periodSeconds`         | How often to perform the probe                                                                                                                                                                                                                                                                                                                                                                                                                                 | `15`                               |
@@ -206,21 +212,25 @@ By default, this chart creates one MongoDB instance as a Primary in a replicaset
 
 For information on running Rocket.Chat in scaled configurations, see the [documentation](https://rocket.chat/docs/installation/docker-containers/high-availability-install/#guide-to-install-rocketchat-as-ha-with-mongodb-replicaset-as-backend) for more details.
 
-### Adding tolerations
+### Adding tolerations and annotations
 
-To add common tolerations to all deployments
+To add common tolerations and annotations to all deployments
 ```yaml
 global:
   tolerations:
     - # here
+  annotations:
+      # here
 ```
 
-Override tolerations for each microservice by adding to respective block's configuration. For example to override the global tolerations for ddp-streamer pods,
+Override tolerations or annotations for each microservice by adding to respective block's configuration. For example to override the global tolerations and annotations for ddp-streamer pods,
 ```yaml
 microservices:
   ddpStreamer:
     tolerations:
       - # add here
+    annotations:
+        # add here
 ```
 
 To override tolerations for `meteor` service, or the main rocket.chat deployment, add to the root tolerations key.
@@ -228,6 +238,12 @@ To override tolerations for `meteor` service, or the main rocket.chat deployment
 tolerations:
   - # ...
 ```
+To override annotations for `meteor` service, or the main rocket.chat deployment, add to the root podAnnotations key.
+```yaml
+podAnnotation:
+    # add here
+```
+
 
 ### Manage MongoDB secrets
 

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -240,7 +240,7 @@ tolerations:
 ```
 To override annotations for `meteor` service, or the main rocket.chat deployment, add to the root podAnnotations key.
 ```yaml
-podAnnotation:
+podAnnotations:
     # add here
 ```
 

--- a/rocketchat/templates/_helpers.tpl
+++ b/rocketchat/templates/_helpers.tpl
@@ -113,3 +113,21 @@ Usage:
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/* Get correct annotations */}}
+{{- define "rocketchat.annotations" -}}
+{{- $name := .name -}}
+{{- $annotations := dict -}}
+{{- with .context }}
+{{- if eq $name "meteor" }}
+{{ $annotations = .Values.podAnnotations}}
+{{- else }}
+{{ $annotations = get (get .Values.microservices $name) "annotations" }}
+{{- end }}
+{{- if (and (kindIs "map" $annotations) (gt (len $annotations) 0)) }}
+{{- toYaml $annotations}}
+{{- else }}
+{{- toYaml .Values.global.annotations}}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -28,14 +28,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
-        {{- end }}
-
-      annotations:
+        {{- end }}   
+      annotations:  
+          {{ include "rocketchat.annotations" (dict "name" "meteor" "context" $) | indent 8 }}
         checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-        {{- end }}
-
 
     spec:
     {{- with .Values.imagePullSecrets }}

--- a/rocketchat/templates/microservices-account-deployment.yaml
+++ b/rocketchat/templates/microservices-account-deployment.yaml
@@ -30,6 +30,11 @@ spec:
         {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
+      annotations:
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
+
     spec:
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "account" "context" $) | indent 8 }}

--- a/rocketchat/templates/microservices-account-deployment.yaml
+++ b/rocketchat/templates/microservices-account-deployment.yaml
@@ -31,10 +31,7 @@ spec:
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-        {{- end }}
-
+        {{ include "rocketchat.annotations" (dict "name" "account" "context" $) | indent 8 }}
     spec:
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "account" "context" $) | indent 8 }}

--- a/rocketchat/templates/microservices-authorization-deployment.yaml
+++ b/rocketchat/templates/microservices-authorization-deployment.yaml
@@ -32,9 +32,7 @@ spec:
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-        {{- end }}
+        {{ include "rocketchat.annotations" (dict "name" "authorization" "context" $) | indent 8 }}
 
     spec:
       tolerations:

--- a/rocketchat/templates/microservices-authorization-deployment.yaml
+++ b/rocketchat/templates/microservices-authorization-deployment.yaml
@@ -31,6 +31,11 @@ spec:
         {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
+      annotations:
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
+
     spec:
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "authorization" "context" $) | indent 8 }}

--- a/rocketchat/templates/microservices-ddp-streamer-deployment.yaml
+++ b/rocketchat/templates/microservices-ddp-streamer-deployment.yaml
@@ -31,9 +31,7 @@ spec:
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-        {{- end }}
+        {{ include "rocketchat.annotations" (dict "name" "ddpStreamer" "context" $) | indent 8 }}
     spec:
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "ddpStreamer" "context" $) | indent 8 }}

--- a/rocketchat/templates/microservices-ddp-streamer-deployment.yaml
+++ b/rocketchat/templates/microservices-ddp-streamer-deployment.yaml
@@ -30,6 +30,10 @@ spec:
         {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
+      annotations:
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
     spec:
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "ddpStreamer" "context" $) | indent 8 }}

--- a/rocketchat/templates/microservices-presence-deployment.yaml
+++ b/rocketchat/templates/microservices-presence-deployment.yaml
@@ -32,9 +32,7 @@ spec:
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-        {{- end }}
+    {{ include "rocketchat.annotations" (dict "name" "presence" "context" $) | indent 8 }}
     spec:
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "presence" "context" $) | indent 8 }}

--- a/rocketchat/templates/microservices-presence-deployment.yaml
+++ b/rocketchat/templates/microservices-presence-deployment.yaml
@@ -31,6 +31,10 @@ spec:
         {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
+      annotations:
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
     spec:
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "presence" "context" $) | indent 8 }}

--- a/rocketchat/templates/microservices-stream-hub-deployment.yaml
+++ b/rocketchat/templates/microservices-stream-hub-deployment.yaml
@@ -32,10 +32,7 @@ spec:
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
       annotations:
-        {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-        {{- end }}
-
+       {{ include "rocketchat.annotations" (dict "name" "streamHub" "context" $) | indent 8 }}
     spec:
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "streamHub" "context" $) | indent 8 }}

--- a/rocketchat/templates/microservices-stream-hub-deployment.yaml
+++ b/rocketchat/templates/microservices-stream-hub-deployment.yaml
@@ -31,6 +31,11 @@ spec:
         {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
+      annotations:
+        {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- end }}
+
     spec:
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "streamHub" "context" $) | indent 8 }}


### PR DESCRIPTION
Annotations can be added globally or separately through the rocketchat.annotations template.  
- Global annotations: the annotations will be mapped to the following pods: account, authorization, presence,ddp-streamer, stream-hub, rocketchat(meteor)
- Separate annotations:  each microservice can have its own set of annotations (it overrides the global annotations) 

