### PR TITLE
fix: don't print `null` when value doesn't exist for globals

### DIFF
--- a/rocketchat/templates/_helpers.tpl
+++ b/rocketchat/templates/_helpers.tpl
@@ -96,6 +96,8 @@ Usage:
     {{- end }}
 {{- end }}
 
+{{/* TODO: fail if types of the following are not what is expected instead of silently ignoring */}}
+
 {{/* Get correct tolerations */}}
 {{- define "rocketchat.tolerations" -}}
 {{- $name := .name -}}
@@ -108,7 +110,7 @@ Usage:
 {{- end }}
 {{- if (and (kindIs "slice" $tolerations) (gt (len $tolerations) 0)) }}
 {{- toYaml $tolerations }}
-{{- else }}
+{{- else if (and (kindIs "slice" .Values.global.tolerations) (gt (len .Values.global.tolerations) 0)) }}
 {{- toYaml .Values.global.tolerations }}
 {{- end }}
 {{- end }}
@@ -126,7 +128,7 @@ Usage:
 {{- end }}
 {{- if (and (kindIs "map" $annotations) (gt (len $annotations) 0)) }}
 {{- toYaml $annotations}}
-{{- else }}
+{{- else if (and (kindIs "map" .Values.global.annotations) (gt (keys .Values.global.annotations | len) 0)) }}
 {{- toYaml .Values.global.annotations}}
 {{- end }}
 {{- end }}

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -3,6 +3,7 @@ global:
   # Tolerations for pod assignment
   # Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
+  annotations: {}
 
 ## Rocket Chat image version
 ## ref: https://hub.docker.com/r/rocketchat/rocket.chat/tags


### PR DESCRIPTION
this lets us use `{{ include "rocketchat.annotations" ... }}` like we already do [here](https://github.com/RocketChat/helm-charts/blob/983996b8e42000ba943afb968662540be9598d9b/rocketchat/templates/chat-deployment.yaml#L33-L34), and not break the manifest by printing `null` or something if even global is empty. 

Ideally we establish a common function that does this. For now I am just repeating.