### PR TITLE
Also use .Values.imagePullSecrets in microservices deployments.

### DIFF
--- a/rocketchat/templates/microservices-account-deployment.yaml
+++ b/rocketchat/templates/microservices-account-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       annotations:
         {{ include "rocketchat.annotations" (dict "name" "account" "context" $) | indent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "account" "context" $) | indent 8 }}
       nodeSelector:

--- a/rocketchat/templates/microservices-authorization-deployment.yaml
+++ b/rocketchat/templates/microservices-authorization-deployment.yaml
@@ -35,6 +35,10 @@ spec:
         {{ include "rocketchat.annotations" (dict "name" "authorization" "context" $) | indent 8 }}
    
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "authorization" "context" $) | indent 8 }}
       nodeSelector:

--- a/rocketchat/templates/microservices-ddp-streamer-deployment.yaml
+++ b/rocketchat/templates/microservices-ddp-streamer-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       annotations:
         {{ include "rocketchat.annotations" (dict "name" "ddpStreamer" "context" $) | indent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "ddpStreamer" "context" $) | indent 8 }}
       nodeSelector:

--- a/rocketchat/templates/microservices-presence-deployment.yaml
+++ b/rocketchat/templates/microservices-presence-deployment.yaml
@@ -34,6 +34,10 @@ spec:
       annotations:
     {{ include "rocketchat.annotations" (dict "name" "presence" "context" $) | indent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "presence" "context" $) | indent 8 }}
       nodeSelector:

--- a/rocketchat/templates/microservices-stream-hub-deployment.yaml
+++ b/rocketchat/templates/microservices-stream-hub-deployment.yaml
@@ -34,6 +34,10 @@ spec:
       annotations:
        {{ include "rocketchat.annotations" (dict "name" "streamHub" "context" $) | indent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
       tolerations:
         {{ include "rocketchat.tolerations" (dict "name" "streamHub" "context" $) | indent 8 }}
       nodeSelector:


### PR DESCRIPTION
We need to be able to use pull secrets also for the microservices deployments.