### PR TITLE
Improve metrics scraping documentation

### DIFF
--- a/rocketchat/Chart.yaml
+++ b/rocketchat/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     condition: postgresql.enabled
   - name: nats
     repository: https://nats-io.github.io/k8s/helm/charts
-    version: 0.15.x
+    version: 1.3.x
     condition: microservices.enabled
 description: Prepare to take off with the ultimate chat platform, experience the next level of team communications
 keywords:

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -304,7 +304,7 @@ If MongoDB and NATS own charts are used in the deployment, add the nodeSelector 
 
 ```yaml
 mongodb:
-enabled: true  
+  enabled: true  
   nodeSelector:
    kubernetes.io/arch: amd64
   affinity:

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -388,6 +388,26 @@ hooks:
     podLabels: {} # here
 ```
 
+## Monitoring
+
+This chart supports two Prometheus monitoring approaches: PodMonitor and ServiceMonitor. Each has distinct advantages depending on your monitoring needs:
+
+#### PodMonitor (Recommended)
+- Scrapes metrics directly from pods matching the selector
+- Captures metrics from pods in all states (including not ready)
+- Provides more comprehensive data for troubleshooting
+- Better visibility into pod lifecycle events
+
+#### ServiceMonitor
+- Uses Kubernetes service selectors to discover pods
+- Only scrapes metrics from pods that are ready and part of the service
+- May miss metrics from pods in transitional states
+- Simpler configuration but less detailed monitoring
+
+#### TLDR
+
+Choose PodMonitor if you need detailed pod-level metrics and troubleshooting data. Use ServiceMonitor if you only need metrics from healthy, service-ready pods.
+
 ## Upgrading
 
 ### To 5.4.3
@@ -434,7 +454,7 @@ Chart contained a bug that would cause `wellknown` deployment to fail to update 
 
 **This is only applicable if you are using Prometheus monitoring with ServiceMonitor.**
 
-The chart has been updated to use PodMonitor instead of ServiceMonitor for Prometheus metrics collection. If you were using ServiceMonitor before, it is recommended to update your values.yaml file and use podMonitor instead. Here's how to migrate:
+The chart has been updated to allow the use PodMonitor instead of ServiceMonitor for Prometheus metrics collection. If you were using ServiceMonitor before and you wan't to migrate from ServiceMonitor to PodMonitor instead. Here's how to migrate:
 
 1. Remove the old ServiceMonitor configuration:
 ```yaml

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -121,11 +121,12 @@ The following table lists the configurable parameters of the Rocket.Chat chart a
 | `global.affinity`                      | common affinity for all pods (rocket.chat and all microservices) | {}  |
 | `tolerations`                          | tolerations for main rocket.chat pods (the `meteor` service) | [] |
 | `microservices.enabled`                | Use [microservices](https://docs.rocket.chat/quick-start/installing-and-updating/micro-services-setup-beta) architecture                                                                                                                                                                                                                                                                                                                                       | `false`                            |
-| `microservices.presence.replicas`      | Number of replicas to run for the given service                                                                                                                                                                                                                                                                                                                                                                                                                | `1`                                |
-| `microservices.ddpStreamer.replicas`   | Idem                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
-| `microservices.account.replicas`      | Idem                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
-| `microservices.authorization.replicas` | Idem                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
-| `microservices.nats.replicas`          | Idem                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
+| `microservices.presence.replicas`      | Number of replicas to run for the presence service                                                                                                                                                                                                                                                                                                                                                                                                                | `1`                                |
+| `microservices.ddpStreamer.replicas`   | Number of replicas to run for the ddpStreamer service                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
+| `microservices.account.replicas`      | Number of replicas to run for the account service                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
+| `microservices.authorization.replicas` | Number of replicas to run for the authorization service                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
+| `microservices.nats.replicaCount`          | Number of replicas to run NATS                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `1`                                |
+| `microservices.nats.promExporter.enabled`          | Enable or Disable metrics collection for NATS                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `false`                                |
 | `microservices.presence.tolerations`      | Pod tolerations | [] |
 | `microservices.ddpStreamer.tolerations`   | Pod tolerations | [] |
 | `microservices.streamHub.tolerations`     | Pod tolerations | [] |
@@ -303,7 +304,7 @@ If MongoDB and NATS own charts are used in the deployment, add the nodeSelector 
 
 ```yaml
 mongodb:
-  enabled: true  
+enabled: true  
   nodeSelector:
    kubernetes.io/arch: amd64
   affinity:
@@ -316,17 +317,17 @@ mongodb:
           values:
           - amd64
 nats:
-    nodeSelector:
-      kubernetes.io/arch: amd64
-    affinity:
-     nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-       nodeSelectorTerms:
-       - matchExpressions:
-         - key: kubernetes.io/arch
-           operator: In
-           values:
-           - amd64
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  affinity:
+    nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+          - amd64
 ```
 ### Manage MongoDB secrets
 
@@ -403,6 +404,26 @@ This chart supports two Prometheus monitoring approaches: PodMonitor and Service
 - Only scrapes metrics from pods that are ready and part of the service
 - May miss metrics from pods in transitional states
 - Simpler configuration but less detailed monitoring
+
+#### Monitoring NATS
+
+The Rocket.Chat chart includes NATS as a dependency for microservices communication. To enable metrics collection for NATS:
+
+1. Enable Prometheus scraping globally:
+```yaml
+prometheusScraping:
+  enabled: true
+```
+
+2. Enable NATS Prometheus exporter:
+```yaml
+microservices:
+  nats:
+    promExporter:
+      enabled: true
+```
+
+For additional NATS configuration options, refer to the [official NATS Helm chart documentation](https://github.com/nats-io/k8s/tree/nats-1.3.1/helm/charts/nats).
 
 #### TLDR
 

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -317,17 +317,23 @@ enabled: true
           values:
           - amd64
 nats:
-  nodeSelector:
-    kubernetes.io/arch: amd64
-  affinity:
-    nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: kubernetes.io/arch
-          operator: In
-          values:
-          - amd64
+  statefulSet:
+    patch:
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value:
+          kubernetes.io/arch: amd64
+      - op: add
+        path: /spec/template/spec/affinity
+        value:
+          nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
 ```
 ### Manage MongoDB secrets
 

--- a/rocketchat/README.md
+++ b/rocketchat/README.md
@@ -20,12 +20,12 @@ By default, the MongoDB chart requires PV support on underlying infrastructure (
 To install the chart with the release name `rocketchat`:
 
 ```console
-$ helm install rocketchat --version "6.26.0" rocketchat/rocketchat --set mongodb.auth.passwords={rocketchatPassword},mongodb.auth.rootPassword=rocketchatRootPassword
+$ helm install rocketchat --version "7.0.0" rocketchat/rocketchat --set mongodb.auth.passwords={rocketchatPassword},mongodb.auth.rootPassword=rocketchatRootPassword
 ```
 
 If you got a registration token for [Rocket.Chat Cloud](https://cloud.rocket.chat), you can also include it: 
 ```console
-$ helm install rocketchat --version "6.26.0" rocketchat/rocketchat --set mongodb.auth.passwords={rocketchatPassword},mongodb.auth.rootPassword=rocketchatRootPassword,registrationToken=<paste the token here>
+$ helm install rocketchat --version "7.0.0" rocketchat/rocketchat --set mongodb.auth.passwords={rocketchatPassword},mongodb.auth.rootPassword=rocketchatRootPassword,registrationToken=<paste the token here>
 ```
 
 Usage of `Values.yaml` file is recommended over using command line arguments `--set`. You must set at least the database password and root password in the values file.
@@ -40,7 +40,7 @@ mongodb:
 
 Now use the following command to deploy
 ```shell
-helm install rocketchat --version "6.26.0" -f Values.yaml rocketchat/rocketchat
+helm install rocketchat --version "7.0.0" -f Values.yaml rocketchat/rocketchat
 ```
 
 > Starting chart version 5.4.3, due to mongodb dependency, username, password and database entries must be arrays of the same length. Rocket.Chat will use the first entries of those arrays for its own use. `mongodb.auth.usernames` array defaults to `{rocketchat}` and `mongodb.auth.databases` array defaults to `{rocketchat}`
@@ -175,7 +175,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install rocketchat --version "6.26.0" -f values.yaml rocketchat/rocketchat
+$ helm install rocketchat --version "7.0.0" -f values.yaml rocketchat/rocketchat
 ```
 
 ### Database Setup
@@ -437,15 +437,15 @@ Choose PodMonitor if you need detailed pod-level metrics and troubleshooting dat
 
 ## Upgrading
 
-### To 6.26.0
+### To 7.0.0
 
-**Important**: Version 6.26.0 introduces breaking changes for NATS due to upgrading the helm chart from 0.13 to 1.3. If you prefer to avoid these changes, you can continue using version 5.26.0 by explicitly specifying it in your helm commands:
+**Important**: Version 7.0.0 introduces breaking changes for NATS due to upgrading the helm chart from 0.13 to 1.3. If you prefer to avoid these changes, you can continue using version 5.26.0 by explicitly specifying it in your helm commands:
 
 ```bash
 helm install rocketchat --version "6.25.0" rocketchat/rocketchat
 ```
 
-If you choose to upgrade to 6.26.0, you'll need to update your NATS configuration as follows:
+If you choose to upgrade to 7.0.0, you'll need to update your NATS configuration as follows:
 
 #### NATS Image version
 

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -386,9 +386,9 @@ microservices:
 nats:
   replicaCount: 1
   promExporter:
-    enabled: false
+    enabled: true
     podMonitor:
-      enabled: true
+      enabled: false
   container:
     image:
       repository: nats

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -384,8 +384,15 @@ microservices:
   authorizationService:
 
 nats:
-  nats:
-    image: nats:2.4-alpine
+  replicaCount: 1
+  promExporter:
+    enabled: false
+    podMonitor:
+      enabled: true
+  container:
+    image:
+      repository: nats
+      tag: 2.4-alpine
 
 federation:
   # host:


### PR DESCRIPTION
This PR performs an upgrade of the NATS Helm chart from version 0.15 to 1.3.

Key Change: With the release of NATS chart 1.0, serviceMonitor support was removed, and podMonitor is now the sole method for metrics scraping.

Documentation: This PR includes updated documentation on how to properly configure and enable NATS metrics scraping using podMonitor.

