### PR TITLE
Add service for microservices metrics on monolith

### DIFF
--- a/rocketchat/templates/service.yaml
+++ b/rocketchat/templates/service.yaml
@@ -49,11 +49,9 @@ kind: Service
 metadata:
   name: {{ template "rocketchat.fullname" . }}-monolith-ms-metrics
   annotations:
-    {{- if .Values.prometheusScraping.enabled }}
     prometheus.io/path: "/metrics"
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{ .Values.prometheusScraping.msPort }}"
-    {{- end }}
 {{- with $service.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/rocketchat/templates/service.yaml
+++ b/rocketchat/templates/service.yaml
@@ -49,6 +49,57 @@ spec:
     app.kubernetes.io/name: {{ include "rocketchat.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 ---
+{{- $service := .Values.service -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "rocketchat.fullname" . }}-monolith-ms-metrics
+  annotations:
+    {{- if .Values.prometheusScraping.enabled }}
+    prometheus.io/path: "/metrics"
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.prometheusScraping.msPort }}"
+    {{- end }}
+{{- with $service.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+  labels:
+    app.kubernetes.io/name: {{ include "rocketchat.name" . }}
+    helm.sh/chart: {{ include "rocketchat.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with $service.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: {{ $service.type }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+  - name: http
+    port: {{ $service.port }}
+    targetPort: http
+    {{- if and (eq "NodePort" $service.type) $service.nodePort }}
+    nodePort: {{ $service.nodePort }}
+    {{- end }}
+    protocol: TCP
+{{- if .Values.prometheusScraping.enabled }}
+  {{- if .Values.microservices.enabled }}
+  - name: moleculer-metrics
+    port: 9458
+    targetPort: 9458
+    protocol: TCP
+  {{- end }}
+  - name: metrics
+    port: {{ .Values.prometheusScraping.port }}
+    targetPort: {{ .Values.prometheusScraping.port }}
+    protocol: TCP
+{{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "rocketchat.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+---
 {{ if .Values.federation.enabled }}
 apiVersion: v1
 kind: Service

--- a/rocketchat/templates/service.yaml
+++ b/rocketchat/templates/service.yaml
@@ -33,13 +33,6 @@ spec:
     nodePort: {{ $service.nodePort }}
     {{- end }}
     protocol: TCP
-{{- if .Values.prometheusScraping.enabled }}
-  {{- if .Values.microservices.enabled }}
-  - name: moleculer-metrics
-    port: 9458
-    targetPort: 9458
-    protocol: TCP
-  {{- end }}
   - name: metrics
     port: {{ .Values.prometheusScraping.port }}
     targetPort: {{ .Values.prometheusScraping.port }}
@@ -49,6 +42,7 @@ spec:
     app.kubernetes.io/name: {{ include "rocketchat.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 ---
+{{- if and .Values.prometheusScraping.enabled .Values.microservices.enabled }}
 {{- $service := .Values.service -}}
 apiVersion: v1
 kind: Service
@@ -72,33 +66,16 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  type: {{ $service.type }}
-  {{- if eq .Values.service.type "LoadBalancer" }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
-  {{- end }}
+  type: ClusterIP
   ports:
-  - name: http
-    port: {{ $service.port }}
-    targetPort: http
-    {{- if and (eq "NodePort" $service.type) $service.nodePort }}
-    nodePort: {{ $service.nodePort }}
-    {{- end }}
-    protocol: TCP
-{{- if .Values.prometheusScraping.enabled }}
-  {{- if .Values.microservices.enabled }}
   - name: moleculer-metrics
     port: 9458
     targetPort: 9458
     protocol: TCP
-  {{- end }}
-  - name: metrics
-    port: {{ .Values.prometheusScraping.port }}
-    targetPort: {{ .Values.prometheusScraping.port }}
-    protocol: TCP
-{{- end }}
   selector:
     app.kubernetes.io/name: {{ include "rocketchat.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{end}}
 ---
 {{ if .Values.federation.enabled }}
 apiVersion: v1


### PR DESCRIPTION
Since only one scrapping annotation is allowed per service we need to define a service per metrics endpoint.  Since Rocket.Chat emits metrics for the monolith on one port and the molecular metrics on another port we have to define a service for both so the targets will register in prometheus