### PR TITLE
Node affinity and node selector fix

### DIFF
--- a/rocketchat/templates/_helpers.tpl
+++ b/rocketchat/templates/_helpers.tpl
@@ -145,9 +145,9 @@ Usage:
 {{ $nodeSelector = get (get .Values.microservices $name) "nodeSelector" }}
 {{- end }}
 {{- if (and (kindIs "map" $nodeSelector) (gt (len $nodeSelector) 0)) }}
-{{- toYaml $nodeSelector | indent 2 }}
+{{- toYaml $nodeSelector }}
 {{- else if (and (kindIs "map" .Values.global.nodeSelector) (gt (keys .Values.global.nodeSelector | len) 0)) }}
-{{- toYaml .Values.global.nodeSelector | indent 2 }}
+{{- toYaml .Values.global.nodeSelector }}
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -163,9 +163,9 @@ Usage:
 {{ $nodeAffinity = get (get .Values.microservices $name) "affinity" }}
 {{- end }}
 {{- if (and (kindIs "map" $nodeAffinity) (gt (len $nodeAffinity) 0)) }}
-{{- toYaml $nodeAffinity | indent 8 }}
+{{- toYaml $nodeAffinity }}
 {{- else if (and (kindIs "map" .Values.global.affinity) (gt (keys .Values.global.affinity | len) 0)) }}
-{{- toYaml .Values.global.affinity | indent 8 }}
+{{- toYaml .Values.global.affinity }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -251,7 +251,7 @@ spec:
 {{- if or .Values.podAntiAffinity .Values.affinity }}
       affinity:
 {{- if .Values.affinity }}
-        {{ include "rocketchat.nodeAffinity" (dict "name" "meteor"  "context" $) | indent 10 }}
+        {{- include "rocketchat.nodeAffinity" (dict "name" "meteor"  "context" $) | indent 8 }}
 {{- end }}
 {{- if eq .Values.podAntiAffinity "hard" }}
         podAntiAffinity:

--- a/rocketchat/templates/hook-verify-mongodb-version.yaml
+++ b/rocketchat/templates/hook-verify-mongodb-version.yaml
@@ -27,17 +27,17 @@ spec:
         {{- end }}
     spec:
       restartPolicy: OnFailure
-        {{- if $.Values.tolerations }}
+      {{- if $.Values.tolerations }}
       tolerations:
-{{ toYaml $.Values.tolerations | indent 8 }}
+        {{- toYaml $.Values.tolerations | nindent 8 }}
       {{- end }}
       {{- if $.Values.hooks.preUpgrade.nodeSelector }}
       nodeSelector:
-      {{ toYaml $.Values.hooks.preUpgrade.nodeSelector | indent 8 }}
+        {{- toYaml $.Values.hooks.preUpgrade.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if $.Values.hooks.preUpgrade.affinity }}
       affinity:
-      {{ toYaml $.Values.hooks.preUpgrade.affinity | indent 8 }}
+        {{- toYaml $.Values.hooks.preUpgrade.affinity | nindent 8 }}
       {{- end }}
 
       containers:


### PR DESCRIPTION
I need to use `nodeAffinity` or `nodeSelector` to limit the nodes to the correct architecture in a multi architecture cluster. While I tried to do that I noticed the the `hook-verify-mongodb-version.yaml` templates currently produces invalid yaml if you provide either.

<details>

<summary>Example of malformed yaml output by the template:</summary>

```yaml
# https://kubernetes.io/docs/concepts/workloads/pods/
apiVersion: batch/v1
kind: Job
metadata:
  name: 'rocketchat-rocketchat-pre-upgrade'
  annotations:
    "helm.sh/hook": pre-upgrade
    "helm.sh/hook-delete-policy": hook-succeeded
spec:
  backoffLimit: 5
  parallelism: 1
  completions: 1
  template:
    metadata:
      name: 'rocketchat-rocketchat-pre-upgrade'
      labels:
        app.kubernetes.io/managed-by: "Helm"
        app.kubernetes.io/instance: "rocketchat"
        helm.sh/chart: "rocketchat-6.25.1"
    spec:
      restartPolicy: OnFailure
      tolerations:
        - effect: NoSchedule
          key: special
          operator: Equal
          value: highcpu
      nodeSelector:
              beta.kubernetes.io/arch: amd64
        other.label: foo
      affinity:
              nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: beta.kubernetes.io/arch
                operator: In
                values:
                - amd64
```
</details>

The error is caussed by an incorrect ussage of the `indent` filter. I fixed this and also improved the indentation of `nodeAffinity` and `nodeSelector` in the Deployments.

<details>

<summary>Fixed output of the tamplate with the purposed changes:</summary>

```yaml
# Source: rocketchat/templates/hook-verify-mongodb-version.yaml
# https://kubernetes.io/docs/concepts/workloads/pods/
apiVersion: batch/v1
kind: Job
metadata:
  name: 'rocketchat-rocketchat-pre-upgrade'
  annotations:
    "helm.sh/hook": pre-upgrade
    "helm.sh/hook-delete-policy": hook-succeeded
spec:
  backoffLimit: 5
  parallelism: 1
  completions: 1
  template:
    metadata:
      name: 'rocketchat-rocketchat-pre-upgrade'
      labels:
        app.kubernetes.io/managed-by: "Helm"
        app.kubernetes.io/instance: "rocketchat"
        helm.sh/chart: "rocketchat-6.25.1"
    spec:
      restartPolicy: OnFailure
      tolerations:
        - effect: NoSchedule
          key: special
          operator: Equal
          value: highcpu
      nodeSelector:
        beta.kubernetes.io/arch: amd64
        other.label: foo
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: beta.kubernetes.io/arch
                operator: In
                values:
                - amd64
```
</details>
