### PR TITLE
feat: chat deployment securityContext logic enhancement

### DIFF
--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -38,10 +38,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      {{- if .Values.securityContext.enabled }}
+      {{- with .Values.securityContext }}
       securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "rocketchat.serviceAccountName" . }}
       {{- if .Values.extraInitContainers }}
@@ -188,6 +187,10 @@ spec:
         - name: OVERWRITE_SETTING_Federation_Matrix_bridge_localpart
           value: "rocket.cat"
         {{end}}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 3000

--- a/rocketchat/templates/tests/test-rocketchat-startup.yaml
+++ b/rocketchat/templates/tests/test-rocketchat-startup.yaml
@@ -9,9 +9,9 @@ spec:
     - name: {{ .Release.Name }}-startup-test
       image: r0zbot/rocketchat-test-utils
       imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-      {{- if .Values.securityContext.enabled }}
+      {{- with .Values.securityContext }}
       securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       env:
         - name: ROCKETCHAT_HOST

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -181,7 +181,10 @@ persistence:
 #     cpu: 300m
 
 securityContext:
-  enabled: true
+  runAsUser: 999
+  fsGroup: 999
+
+containerSecurityContext:
   runAsUser: 999
   fsGroup: 999
 


### PR DESCRIPTION
Updating logic for chat-deployment pod and container level securityContext to match other templates with a bit extra resiliency to be able to handle empty array if necessary.

For issue https://github.com/RocketChat/helm-charts/issues/113

---

rebased pr #142  on to master.