### PR TITLE
Control MongoDB and NATS pod/servicemonitor via variables

### DIFF
--- a/rocketchat/templates/mongodb-monitor.yaml
+++ b/rocketchat/templates/mongodb-monitor.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.mongodb.metrics.enabled (not .Values.mongodb.metrics.serviceMonitor.enabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{ if and .Values.serviceMonitor.enabled  .Values.mongodb.metrics.enabled (not .Values.mongodb.metrics.serviceMonitor.enabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/rocketchat/templates/nats-monitor.yaml
+++ b/rocketchat/templates/nats-monitor.yaml
@@ -1,5 +1,5 @@
 {{ if and .Values.nats.exporter.enabled (not .Values.nats.exporter.serviceMonitor.enabled) }}
-{{ if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{ if and .Values.podMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 {{/* if there is the monitoring.coreos.com/v1 API, use it */}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor


### PR DESCRIPTION
Before this pull request, MongoDB ServiceMonitor and NATS PodMonitor did not depend on the value of `serviceMonitor.enabled` and `podMonitor.enabled`.

This impact my deployments, and I am not sure it is intentional. Thus this commit.