### PR TITLE
Make ingressClassName optional for monitoring chart

### DIFF
--- a/monitoring/Chart.yaml
+++ b/monitoring/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 appVersion: 0.83.0
 
 # Chart version
-version: 0.0.6
+version: 0.0.7
 
 dependencies:
 - name: kube-prometheus-stack

--- a/monitoring/templates/ingress.yaml
+++ b/monitoring/templates/ingress.yaml
@@ -1,7 +1,4 @@
 {{ if and .Values.ingress.enabled (or .Values.ingress.prometheus.enabled .Values.ingress.grafana.enabled) }}
-{{- if not .Values.ingress.ingressClassName }}
-  {{- fail "ingress.ingressClassName is required when ingress.enabled is true, and it must be one of: nginx, traefik" }}
-{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -9,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ingressClassName: "{{ .Values.ingress.ingressClassName }}"
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     {{- if .Values.ingress.prometheus.enabled }}
       {{- if and (not .Values.ingress.prometheus.host) (not .Values.ingress.prometheus.path) }}


### PR DESCRIPTION
Make the ingressClassname optional for the monitoring cluster, allowing it to use the default from the cluster.