### PR TITLE
Unset containerSecurityContext.fsGroup

### DIFF
--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -186,7 +186,6 @@ securityContext:
 
 containerSecurityContext:
   runAsUser: 999
-  fsGroup: 999
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
`securityContext.fsGroup` cannot be set at the container level. See [https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1)