### PR TITLE
Add liveness / readiness check to ddp-streamer

### DIFF
--- a/rocketchat/templates/microservices-ddp-streamer-deployment.yaml
+++ b/rocketchat/templates/microservices-ddp-streamer-deployment.yaml
@@ -78,10 +78,33 @@ spec:
           value: {{ .Values.prometheusScraping.msPort | default "9458" | quote }}
         {{- end }}
         ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
         {{- if .Values.prometheusScraping.enabled }}
         - name: ms-metrics
           containerPort: {{ .Values.prometheusScraping.msPort }}
         {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 2
+          timeoutSeconds: 1
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
         volumeMounts: 
         {{- if .Values.extraVolumeMounts }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 8 }}


### PR DESCRIPTION
This adds health check probes and exposes a new HTTP port in the `microservices-ddp-streamer-deployment.yaml` template to improve container monitoring and readiness. These changes help Kubernetes better manage the service lifecycle and ensure the application is running and ready to serve traffic.

Container health and readiness improvements:

* Added a new HTTP port (`http`, port 3000) to the container's ports list for health checks and service access.
* Introduced a `livenessProbe` and a `readinessProbe` that use HTTP GET requests to the `/health` endpoint on the new HTTP port, enabling Kubernetes to monitor the container's health and readiness state.