### PR TITLE
Supported 'LoadBarancerClass' to Service

### DIFF
--- a/rocketchat/templates/service.yaml
+++ b/rocketchat/templates/service.yaml
@@ -24,6 +24,7 @@ spec:
   type: {{ $service.type }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
   {{- end }}
   ports:
   - name: http

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -255,6 +255,7 @@ service:
 
   ## Optional when LoadBalancer specified ServiceType.
   loadBalancerIP: ""
+  loadBalancerClass: ""
 
 ## Optional custom labels for the deployment resource.
 deploymentLabels: {}


### PR DESCRIPTION
This PR introduces an optional `service.loadBalancerClass` value and passes it to the Service spec.

It is useful for clusters with multiple LoadBalancer implementations and is backward compatible.
