### PR TITLE
Add ability to configure annotations on deployments

### DIFF
--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     {{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
     {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/rocketchat/templates/microservices-account-deployment.yaml
+++ b/rocketchat/templates/microservices-account-deployment.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- if .Values.deploymentLabels }}
       {{- toYaml .Values.deploymentLabels | nindent 4 }}
     {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.microservices.account.replicas }}
   selector:

--- a/rocketchat/templates/microservices-authorization-deployment.yaml
+++ b/rocketchat/templates/microservices-authorization-deployment.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- if .Values.deploymentLabels }}
       {{- toYaml .Values.deploymentLabels | nindent 4 }}
     {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.microservices.authorization.replicas }}
   revisionHistoryLimit: 0

--- a/rocketchat/templates/microservices-ddp-streamer-deployment.yaml
+++ b/rocketchat/templates/microservices-ddp-streamer-deployment.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- if .Values.deploymentLabels }}
       {{- toYaml .Values.deploymentLabels | nindent 4 }}
     {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.microservices.ddpStreamer.replicas }}
   selector:

--- a/rocketchat/templates/microservices-presence-deployment.yaml
+++ b/rocketchat/templates/microservices-presence-deployment.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- if .Values.deploymentLabels }}
       {{- toYaml .Values.deploymentLabels | nindent 4 }}
     {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.microservices.presence.replicas }}
   revisionHistoryLimit: 0

--- a/rocketchat/templates/microservices-stream-hub-deployment.yaml
+++ b/rocketchat/templates/microservices-stream-hub-deployment.yaml
@@ -18,6 +18,10 @@ metadata:
     {{- if .Values.deploymentLabels }}
       {{- toYaml .Values.deploymentLabels | nindent 4 }}
     {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{ toYaml .Values.deploymentAnnotations | indent 4 }}
+  {{- end }}
 spec:
   replicas: 1
   revisionHistoryLimit: 0

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -257,6 +257,9 @@ service:
 ## Optional custom labels for the deployment resource.
 deploymentLabels: {}
 
+## Optional custom annotations for the deployment resource.
+deploymentAnnotations: {}
+
 ## Optional Pod Labels.
 podLabels: {}
 


### PR DESCRIPTION
As described in the title.

The use case is having dynamic mongodb passwords. We rotate those every 12 hours, and must restart the rocketchat pods whenever that happens, which is triggered by https://github.com/stakater/Reloader, which requires an annotation on the deployments.