### PR TITLE
feat: inject enterprise license and configure related settings in dep…

### DIFF
--- a/rocketchat/templates/chat-deployment.yaml
+++ b/rocketchat/templates/chat-deployment.yaml
@@ -102,12 +102,16 @@ spec:
               name: {{ template "rocketchat.fullname" . }}
               key: reg-token
         {{- end }}
-        {{- if and .Values.license .Release.IsInstall }}
-        - name: ROCKETCHAT_LICENSE
+        {{- if .Values.license }}
+        - name: OVERWRITE_SETTING_Enterprise_License
           valueFrom:
             secretKeyRef:
               name: {{ template "rocketchat.fullname" . }}
               key: license
+        - name: OVERWRITE_SETTING_Show_Setup_Wizard
+          value: "completed"
+        - name: LICENSE_DEBUG
+          value: "true"
         {{- end }}
         {{- if .Values.prometheusScraping.enabled }}
         - name: OVERWRITE_SETTING_Prometheus_Enabled

--- a/rocketchat/values.yaml
+++ b/rocketchat/values.yaml
@@ -87,7 +87,11 @@ extraInitContainers: []
 ## Specifies a Registration Token (obtainable at https://cloud.rocket.chat)
 #registrationToken: ""
 
-## Specifies an Enterprise License
+## Specifies an Enterprise License key
+## When set, automatically configures:
+##   OVERWRITE_SETTING_Enterprise_License - injects the license key
+##   OVERWRITE_SETTING_Show_Setup_Wizard  - marks setup as completed
+##   LICENSE_DEBUG                        - enables license debug logging
 # license: ""
 
 ## Pod anti-affinity can prevent the scheduler from placing RocketChat replicas on the same node.


### PR DESCRIPTION
Updates how the Enterprise License is configured in the Rocket.Chat Helm chart. The main change is that setting the `license` value now automatically injects additional environment variables to streamline the setup process and enable license debugging.

Enterprise License configuration improvements:

* Changed the environment variable from `ROCKETCHAT_LICENSE` to `OVERWRITE_SETTING_Enterprise_License` in `chat-deployment.yaml`, and added `OVERWRITE_SETTING_Show_Setup_Wizard` (set to `"completed"`) and `LICENSE_DEBUG` (set to `"true"`) when a license is provided. This ensures the setup wizard is skipped and license debug logging is enabled automatically.
* Updated documentation in `values.yaml` to clarify that setting the `license` key now also configures the above environment variables automatically.