### PR TITLE
fix(mongodb): do not render the MongoDB ServiceMonitor when mongodb.enabled is false

### DIFF
--- a/rocketchat/templates/mongodb-monitor.yaml
+++ b/rocketchat/templates/mongodb-monitor.yaml
@@ -1,4 +1,4 @@
-{{ if and .Values.mongodb.serviceMonitor.enabled .Values.mongodb.metrics.enabled (not .Values.mongodb.metrics.serviceMonitor.enabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{ if and .Values.mongodb.enabled .Values.mongodb.serviceMonitor.enabled .Values.mongodb.metrics.enabled (not .Values.mongodb.metrics.serviceMonitor.enabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
### Problem

`rocketchat/templates/mongodb-monitor.yaml` gates on `mongodb.serviceMonitor.enabled`, `mongodb.metrics.enabled` and the ServiceMonitor CRD being present — but never on **`mongodb.enabled`**.

`Chart.yaml` declares the MongoDB dependency with `condition: mongodb.enabled`, so setting it to `false` correctly disables the subchart. The parent chart's own ServiceMonitor template ignores that and renders anyway.

The resulting object selects `app.kubernetes.io/name=mongodb`, which nothing in the release provides, so it sits in the cluster with **zero targets indefinitely**. That is worse than having no ServiceMonitor at all: it shows up in `kubectl get servicemonitor` and in Prometheus's config as though MongoDB were monitored, which is exactly the kind of thing nobody re-checks.

This affects anyone running MongoDB outside the chart — an external cluster via `externalMongodbUrl`, or an operator-managed replica set. We hit it with the MongoDB Community/MCK operator: the ServiceMonitor had been present and scraping nothing for **193 days** before we noticed.

### Fix

One line — add the dependency condition the template already implies:

```diff
-{{ if and .Values.mongodb.serviceMonitor.enabled .Values.mongodb.metrics.enabled ... }}
+{{ if and .Values.mongodb.enabled .Values.mongodb.serviceMonitor.enabled .Values.mongodb.metrics.enabled ... }}
```

### Reproduction

```bash
cat > values.yaml <<'EOF'
mongodb:
  enabled: false
EOF

helm template rc . --api-versions monitoring.coreos.com/v1 -f values.yaml \
  | grep 'name: rc-mongodb'
```

Note `--api-versions` is required: the template also tests `.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"`, so without it nothing renders and the bug is invisible to a plain `helm template`.

| | `rc-mongodb` ServiceMonitor rendered? |
|---|---|
| master, `mongodb.enabled: false` | **yes** |
| this PR, `mongodb.enabled: false` | no |
| this PR, `mongodb.enabled: true` | yes (unchanged) |

### Relationship to #189

#189 touches the same template but addresses a different aspect — making it honour the top-level `serviceMonitor.enabled`. The two are independent and compose cleanly: #189 decides *whether ServiceMonitors are wanted at all*, this decides *whether there is a MongoDB to monitor*. Happy to rebase on top of it if that is preferred.
