### PR TITLE
Add dockerhub OIDC login

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,7 @@ on:
     secrets:
       github-token:
         required: true
-      docker-username:
-        required: true
-      docker-password:
+      docker-oidc-id:
         required: true
     inputs:
       tag:
@@ -100,6 +98,8 @@ jobs:
       - set-versions
     # prettier-ignore
     if: '! contains(inputs.tag, ''rc'')'
+    permissions:
+      id-token: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ inputs.tag }}
@@ -107,5 +107,4 @@ jobs:
       chartName: ${{ inputs.chartName }}
     secrets:
       github-token: ${{ secrets.github-token }}
-      docker-username: ${{ secrets.docker-username }}
-      docker-password: ${{ secrets.docker-password }}
+      docker-oidc-id: ${{ secrets.docker-oidc-id }}

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -46,6 +46,8 @@ jobs:
   run:
     needs:
       - config
+    permissions:
+      id-token: write
     uses: ./.github/workflows/main.yml
     with:
       tag: ${{ needs.config.outputs.tag }}
@@ -53,5 +55,4 @@ jobs:
       chartName: ${{ inputs.chartName }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-      docker-username: ${{ secrets.DOCKER_USERNAME }}
-      docker-password: ${{ secrets.DOCKER_PASSWORD }}
+      docker-oidc-id: ${{ secrets.DOCKER_OIDC_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,7 @@ on:
     secrets:
       github-token:
         required: true
-      docker-username:
-        required: true
-      docker-password:
+      docker-oidc-id:
         required: true
     inputs:
       chartVersion:
@@ -26,6 +24,9 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Clone helm repo
         uses: actions/checkout@v2
@@ -63,11 +64,17 @@ jobs:
       - name: Install ORAS
         uses: oras-project/setup-oras@v1
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - name: OIDC token
+        id: docker_oidc
+        uses: docker/oidc-action@96ba694c64860c7209bcd1ede7d698c71564ef78 # v1.2.0
         with:
-          username: ${{ secrets.docker-username }}
-          password: ${{ secrets.docker-password }}
+          connection-id: ${{ secrets.docker-oidc-id }}
+
+      - name: Docker OIDC login
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: rocketchat
+          password: ${{ steps.docker_oidc.outputs.token }}
 
       - name: Push chart to Docker Hub OCI
         shell: bash


### PR DESCRIPTION
Replaces Docker Hub username/password login with OIDC-based login (using `DOCKER_OIDC_ID`), matching https://github.com/RocketChat/airlock/pull/32.